### PR TITLE
施設画像登録機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **ORM**: SQLModel
 - **AI**: Google Gemini 2.5 Flash-Lite (Google AI API直接呼び出し)
 - **データ分析**: Pandas
+- **ストレージ**: S3互換（RustFS / 施設画像保存用）
 - **コンテナ**: Docker & Docker Compose
 
 ### アーキテクチャの特徴
@@ -54,6 +55,20 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=marketing_planner
 ```
 
+#### S3互換ストレージ（施設画像保存用）
+
+施設画像のアップロード・表示を使う場合は、`backend/.env` に以下を追加してください（Docker Compose の `storage` を使う場合の例）。
+
+```env
+# Docker 内: http://storage:9000 / ローカル単体実行: http://localhost:9000
+S3_ENDPOINT_URL=http://storage:9000
+S3_ACCESS_KEY=rustfsadmin
+S3_SECRET_KEY=rustfsadmin
+S3_BUCKET=facility-images
+```
+
+未設定のまま施設画像にアクセスすると「ストレージ接続に失敗しました」となります。`backend/env.example` にも同じ項目が記載されています。
+
 ### 2. Docker環境の起動
 
 ```bash
@@ -71,6 +86,7 @@ docker compose up -d --build
 - **APIドキュメント（Swagger）**: http://localhost:8000/docs
 - **APIドキュメント（ReDoc）**: http://localhost:8000/redoc
 - **データベース**: localhost:5432
+- **S3互換ストレージ（RustFS）コンソール**: http://localhost:9001
 
 ### 4. 開発コマンド
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -129,12 +129,16 @@ backend/
 
 ### 1. 環境変数の設定
 
-`backend/.env` ファイルを作成し、以下を設定：
+環境ごとに `backend/.env` を用意し、必要な値を設定してください。
 
-```env
-DATABASE_URL=postgresql://postgres:postgres@db:5432/marketing_planner
-GOOGLE_API_KEY=your_google_api_key_here
+```bash
+# env.example をコピーして .env を作成
+cp env.example .env
+# .env を編集して必須項目・オプションを設定
 ```
+
+**必須**: `DATABASE_URL`, `GOOGLE_API_KEY`  
+**施設画像利用時**: `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`（Docker 内は `S3_ENDPOINT_URL=http://storage:9000`）
 
 詳細は `ENV_SETUP.md` を参照してください。
 

--- a/backend/app/api/facility_hotels.py
+++ b/backend/app/api/facility_hotels.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/facility/hotels", tags=["Facility Hotels"])
 
 # 施設画像の種別（API・DB で共通）
 FACILITY_IMAGE_TYPES = [
-    "panorama", "room", "bath", "cuisine", "lobby",
+    "exterior", "interior", "room", "bath", "cuisine", "lobby",
     "restaurant", "sightseeing", "staff", "other",
 ]
 FACILITY_IMAGE_MAX_COUNT = 10
@@ -56,6 +56,12 @@ class FacilityImageItemResponse(BaseModel):
     description: str
     type: str
     order: int
+
+
+class FacilityImageUpdateRequest(BaseModel):
+    """施設画像メタデータ更新リクエスト"""
+    type: Optional[str] = None
+    description: Optional[str] = None
 
 
 class HotelResponse(BaseModel):
@@ -615,6 +621,76 @@ async def delete_facility_image(
     flag_modified(hotel, "facility_images")
     session.add(hotel)
     session.commit()
+
+
+@router.put("/{hotel_id}/images/{image_key}", response_model=FacilityImageItemResponse)
+async def update_facility_image(
+    hotel_id: int,
+    image_key: str,
+    request: FacilityImageUpdateRequest,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session),
+):
+    """指定 key の施設画像の種別・説明を更新する（実ファイルは変更しない）。"""
+    # 権限確認（owner または editor）
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id,
+        )
+    ).first()
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+    if permission.role not in [FacilityAdminHotelRole.owner, FacilityAdminHotelRole.editor]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="編集権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    images = list(hotel.facility_images or [])
+    target_index = next((i for i, item in enumerate(images) if item.get("key") == image_key), None)
+    if target_index is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="指定された画像が見つかりません",
+        )
+
+    item = dict(images[target_index])
+    if request.type is not None:
+        if request.type not in FACILITY_IMAGE_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"無効な種別です。有効な値: {', '.join(FACILITY_IMAGE_TYPES)}",
+            )
+        item["type"] = request.type
+    if request.description is not None:
+        item["description"] = request.description
+
+    images[target_index] = item
+    hotel.facility_images = images
+    hotel.updated_at = datetime.utcnow()
+    flag_modified(hotel, "facility_images")
+    session.add(hotel)
+    session.commit()
+    session.refresh(hotel)
+
+    return FacilityImageItemResponse(
+        key=item["key"],
+        url=item["url"],
+        description=item.get("description", ""),
+        type=item["type"],
+        order=item.get("order", 0),
+    )
 
 
 # ============================================

--- a/backend/app/api/facility_hotels.py
+++ b/backend/app/api/facility_hotels.py
@@ -1,17 +1,28 @@
 """施設管理API（施設管理者用）"""
+import os
 from typing import List, Optional
 from datetime import datetime
-from fastapi import APIRouter, Depends, HTTPException, status, Query, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, status, Query, UploadFile, File, Form
 from sqlmodel import Session, select
+from sqlalchemy.orm.attributes import flag_modified
 from pydantic import BaseModel
 
 from app.core.database import get_session
 from app.core.llm import get_llm_client
+from app.core.image_utils import save_facility_image, delete_facility_image_file
 from app.models import FacilityAdmin, FacilityAdminHotel, Hotel, FacilityAdminHotelRole
 from app.auth.dependencies import get_current_facility_admin
 from sqlmodel import select
 
 router = APIRouter(prefix="/facility/hotels", tags=["Facility Hotels"])
+
+# 施設画像の種別（API・DB で共通）
+FACILITY_IMAGE_TYPES = [
+    "panorama", "room", "bath", "cuisine", "lobby",
+    "restaurant", "sightseeing", "staff", "other",
+]
+FACILITY_IMAGE_MAX_COUNT = 10
+ALLOWED_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"]
 
 
 class HotelCreateRequest(BaseModel):
@@ -38,6 +49,15 @@ class HotelUpdateRequest(BaseModel):
     cv_url: Optional[str] = None
 
 
+class FacilityImageItemResponse(BaseModel):
+    """施設画像1件のレスポンス"""
+    key: str
+    url: str
+    description: str
+    type: str
+    order: int
+
+
 class HotelResponse(BaseModel):
     """施設レスポンス"""
     id: int
@@ -50,6 +70,7 @@ class HotelResponse(BaseModel):
     strengths: dict
     cv_url: Optional[str]
     hotel_assets: dict = {}  # 施設の資産情報
+    facility_images: list = []  # 施設画像（最大10件）
     role: str  # 施設管理者の権限
     
     class Config:
@@ -113,6 +134,7 @@ async def list_my_hotels(
                 strengths=hotel.strengths,
                 cv_url=hotel.cv_url,
                 hotel_assets=hotel.hotel_assets or {},
+                facility_images=hotel.facility_images if hotel.facility_images else [],
                 role=perm.role,
             ))
             hotel_permissions_map[hotel.id] = perm.role
@@ -168,6 +190,7 @@ async def list_my_hotels(
                     strengths=hotel.strengths,
                     cv_url=hotel.cv_url,
                     hotel_assets=hotel.hotel_assets or {},
+                    facility_images=hotel.facility_images if hotel.facility_images else [],
                     role=FacilityAdminHotelRole.owner,
                 ))
         
@@ -253,6 +276,7 @@ async def create_hotel(
         strengths=hotel.strengths,
         cv_url=hotel.cv_url,
         hotel_assets=hotel.hotel_assets or {},
+        facility_images=hotel.facility_images if hotel.facility_images else [],
         role=FacilityAdminHotelRole.owner,
     )
 
@@ -303,6 +327,7 @@ async def get_hotel(
         strengths=hotel.strengths,
         cv_url=hotel.cv_url,
         hotel_assets=hotel.hotel_assets or {},
+        facility_images=hotel.facility_images if hotel.facility_images else [],
         role=permission.role,
         created_at=hotel.created_at,
         updated_at=hotel.updated_at,
@@ -386,6 +411,7 @@ async def update_hotel(
         strengths=hotel.strengths,
         cv_url=hotel.cv_url,
         hotel_assets=hotel.hotel_assets or {},
+        facility_images=hotel.facility_images if hotel.facility_images else [],
         role=permission.role,
         created_at=hotel.created_at,
         updated_at=hotel.updated_at,
@@ -445,6 +471,149 @@ async def delete_hotel(
     
     # 施設を削除
     session.delete(hotel)
+    session.commit()
+
+
+# ============================================
+# 施設画像 API
+# ============================================
+
+@router.post("/{hotel_id}/images", response_model=FacilityImageItemResponse, status_code=status.HTTP_201_CREATED)
+async def upload_facility_image(
+    hotel_id: int,
+    file: UploadFile = File(...),
+    type: str = Form(...),
+    description: str = Form(""),
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session),
+):
+    """
+    施設画像を1枚アップロードする。
+    1MB 超過時はサーバ側で圧縮して保存する。1施設あたり最大10枚まで。
+    """
+    # 権限確認（owner または editor）
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id,
+        )
+    ).first()
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+    if permission.role not in [FacilityAdminHotelRole.owner, FacilityAdminHotelRole.editor]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="編集権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    images = list(hotel.facility_images or [])
+    if len(images) >= FACILITY_IMAGE_MAX_COUNT:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"施設画像は最大{FACILITY_IMAGE_MAX_COUNT}枚までです",
+        )
+
+    if type not in FACILITY_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"無効な種別です。有効な値: {', '.join(FACILITY_IMAGE_TYPES)}",
+        )
+
+    file_ext = os.path.splitext(file.filename or "")[1].lower()
+    if file_ext not in ALLOWED_IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"無効なファイル形式です。有効な形式: {', '.join(ALLOWED_IMAGE_EXTENSIONS)}",
+        )
+
+    content = await file.read()
+    key, url = save_facility_image(hotel_id, content, file_ext)
+
+    order = max((item.get("order", 0) for item in images), default=-1) + 1
+    new_item = {
+        "key": key,
+        "url": url,
+        "description": description or "",
+        "type": type,
+        "order": order,
+    }
+    images.append(new_item)
+    hotel.facility_images = images
+    hotel.updated_at = datetime.utcnow()
+    flag_modified(hotel, "facility_images")
+    session.add(hotel)
+    session.commit()
+    session.refresh(hotel)
+
+    return FacilityImageItemResponse(
+        key=new_item["key"],
+        url=new_item["url"],
+        description=new_item["description"],
+        type=new_item["type"],
+        order=new_item["order"],
+    )
+
+
+@router.delete("/{hotel_id}/images/{image_key}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_facility_image(
+    hotel_id: int,
+    image_key: str,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session),
+):
+    """指定 key の施設画像を削除する（DB と実ファイルの両方）。"""
+    # 権限確認（owner または editor）
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id,
+        )
+    ).first()
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+    if permission.role not in [FacilityAdminHotelRole.owner, FacilityAdminHotelRole.editor]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="編集権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    images = hotel.facility_images if hotel.facility_images else []
+    new_images = [item for item in images if item.get("key") != image_key]
+    if len(new_images) == len(images):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="指定された画像が見つかりません",
+        )
+
+    # 削除対象の url を取得してから実ファイルを削除
+    removed = next((item for item in images if item.get("key") == image_key), None)
+    if removed:
+        delete_facility_image_file(hotel_id, image_key, removed.get("url", ""))
+
+    hotel.facility_images = new_images
+    hotel.updated_at = datetime.utcnow()
+    flag_modified(hotel, "facility_images")
+    session.add(hotel)
     session.commit()
 
 

--- a/backend/app/api/facility_hotels.py
+++ b/backend/app/api/facility_hotels.py
@@ -543,7 +543,13 @@ async def upload_facility_image(
         )
 
     content = await file.read()
-    key, url = save_facility_image(hotel_id, content, file_ext)
+    try:
+        key, url = save_facility_image(hotel_id, content, file_ext)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ストレージ接続に失敗しました",
+        )
 
     order = max((item.get("order", 0) for item in images), default=-1) + 1
     new_item = {
@@ -611,10 +617,16 @@ async def delete_facility_image(
             detail="指定された画像が見つかりません",
         )
 
-    # 削除対象の url を取得してから実ファイルを削除
+    # 削除対象の url を取得してから S3 上のオブジェクトを削除
     removed = next((item for item in images if item.get("key") == image_key), None)
     if removed:
-        delete_facility_image_file(hotel_id, image_key, removed.get("url", ""))
+        try:
+            delete_facility_image_file(hotel_id, image_key, removed.get("url", ""))
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="ストレージ接続に失敗しました",
+            )
 
     hotel.facility_images = new_images
     hotel.updated_at = datetime.utcnow()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,7 +37,13 @@ class Settings(BaseSettings):
     # 初期システムアドミン設定（オプション）
     INITIAL_ADMIN_EMAIL: Optional[str] = None
     INITIAL_ADMIN_PASSWORD: Optional[str] = None
-    
+
+    # S3互換ストレージ（施設画像保存用）。未設定時は get_s3_client 利用時にエラーになる。
+    S3_ENDPOINT_URL: Optional[str] = None
+    S3_ACCESS_KEY: Optional[str] = None
+    S3_SECRET_KEY: Optional[str] = None
+    S3_BUCKET: str = "facility-images"
+
     class Config:
         env_file = ".env"
         case_sensitive = True

--- a/backend/app/core/image_utils.py
+++ b/backend/app/core/image_utils.py
@@ -1,0 +1,105 @@
+"""
+施設画像の保存・圧縮ヘルパー
+
+1MB を超える画像はサーバ側でリサイズ・圧縮してから保存する。
+"""
+import os
+import uuid
+from io import BytesIO
+
+# 1MB
+FACILITY_IMAGE_MAX_BYTES = 1048576
+
+# 圧縮時の長辺最大ピクセル
+FACILITY_IMAGE_MAX_SIDE = 1920
+
+# JPEG 圧縮品質
+JPEG_QUALITY = 85
+
+
+def _get_static_dir() -> str:
+    """backend/static の絶対パスを返す"""
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "static",
+    )
+
+
+def compress_image(content: bytes, ext: str) -> bytes:
+    """
+    画像をリサイズ・圧縮する。
+    長辺を FACILITY_IMAGE_MAX_SIDE 以下にし、JPEG 品質 85 で保存する。
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        return content
+
+    try:
+        img = Image.open(BytesIO(content)).convert("RGB")
+    except Exception:
+        return content
+
+    w, h = img.size
+    if w <= FACILITY_IMAGE_MAX_SIDE and h <= FACILITY_IMAGE_MAX_SIDE:
+        out = BytesIO()
+        img.save(out, "JPEG", quality=JPEG_QUALITY, optimize=True)
+        return out.getvalue()
+
+    if w >= h:
+        new_w = FACILITY_IMAGE_MAX_SIDE
+        new_h = int(h * (FACILITY_IMAGE_MAX_SIDE / w))
+    else:
+        new_h = FACILITY_IMAGE_MAX_SIDE
+        new_w = int(w * (FACILITY_IMAGE_MAX_SIDE / h))
+
+    img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+    out = BytesIO()
+    img.save(out, "JPEG", quality=JPEG_QUALITY, optimize=True)
+    return out.getvalue()
+
+
+def save_facility_image(hotel_id: int, content: bytes, ext: str) -> tuple[str, str]:
+    """
+    施設画像を保存し、(key, url) を返す。
+
+    - 1MB 超過時は圧縮してから保存する。
+    - ext は ".jpg" などドット付きで渡す。圧縮時は .jpg で保存する。
+    - key: 一意キー（削除時に使用）
+    - url: 配信用 URL（例: /static/hotel_images/5/abc123.jpg）
+    """
+    if len(content) > FACILITY_IMAGE_MAX_BYTES:
+        content = compress_image(content, ext)
+        ext = ".jpg"
+
+    key = uuid.uuid4().hex[:12]
+    filename = f"{key}{ext}"
+    static_dir = _get_static_dir()
+    hotel_dir = os.path.join(static_dir, "hotel_images", str(hotel_id))
+    os.makedirs(hotel_dir, exist_ok=True)
+    filepath = os.path.join(hotel_dir, filename)
+
+    with open(filepath, "wb") as f:
+        f.write(content)
+
+    url = f"/static/hotel_images/{hotel_id}/{filename}"
+    return (key, url)
+
+
+def delete_facility_image_file(hotel_id: int, key: str, url: str) -> None:
+    """
+    施設画像の実ファイルを削除する。
+    url からファイル名を抽出して削除する。存在しない場合は何もしない。
+    """
+    if not url or "/static/hotel_images/" not in url:
+        return
+    filename = url.split("/")[-1]
+    if not filename or not filename.startswith(key):
+        return
+    static_dir = _get_static_dir()
+    filepath = os.path.join(static_dir, "hotel_images", str(hotel_id), filename)
+    if os.path.exists(filepath):
+        try:
+            os.remove(filepath)
+        except OSError:
+            pass

--- a/backend/app/core/image_utils.py
+++ b/backend/app/core/image_utils.py
@@ -1,11 +1,13 @@
 """
 施設画像の保存・圧縮ヘルパー
 
-1MB を超える画像はサーバ側でリサイズ・圧縮してから保存する。
+1MB を超える画像はサーバ側でリサイズ・圧縮してから S3 に保存する。
 """
-import os
 import uuid
 from io import BytesIO
+
+from app.core.config import settings
+from app.core.s3_client import get_s3_client
 
 # 1MB
 FACILITY_IMAGE_MAX_BYTES = 1048576
@@ -15,14 +17,6 @@ FACILITY_IMAGE_MAX_SIDE = 1920
 
 # WebP 圧縮品質
 WEBP_QUALITY = 85
-
-
-def _get_static_dir() -> str:
-    """backend/static の絶対パスを返す"""
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-        "static",
-    )
 
 
 def _image_to_webp(img: "Image.Image", quality: int = WEBP_QUALITY) -> bytes:
@@ -80,7 +74,7 @@ def _convert_to_webp(content: bytes, ext: str) -> bytes:
 
 def save_facility_image(hotel_id: int, content: bytes, ext: str) -> tuple[str, str]:
     """
-    施設画像を WebP 形式で保存し、(key, url) を返す。
+    施設画像を WebP 形式で S3 に保存し、(key, url) を返す。
 
     - 1MB 超過時はリサイズ・圧縮してから WebP で保存する。
     - 1MB 以下も WebP に変換して保存する。
@@ -95,13 +89,15 @@ def save_facility_image(hotel_id: int, content: bytes, ext: str) -> tuple[str, s
 
     key = uuid.uuid4().hex[:12]
     filename = f"{key}.webp"
-    static_dir = _get_static_dir()
-    hotel_dir = os.path.join(static_dir, "hotel_images", str(hotel_id))
-    os.makedirs(hotel_dir, exist_ok=True)
-    filepath = os.path.join(hotel_dir, filename)
+    s3_key = f"hotel_images/{hotel_id}/{filename}"
 
-    with open(filepath, "wb") as f:
-        f.write(content)
+    client = get_s3_client()
+    client.put_object(
+        Bucket=settings.S3_BUCKET,
+        Key=s3_key,
+        Body=content,
+        ContentType="image/webp",
+    )
 
     url = f"/static/hotel_images/{hotel_id}/{filename}"
     return (key, url)
@@ -109,7 +105,7 @@ def save_facility_image(hotel_id: int, content: bytes, ext: str) -> tuple[str, s
 
 def delete_facility_image_file(hotel_id: int, key: str, url: str) -> None:
     """
-    施設画像の実ファイルを削除する。
+    施設画像を S3 から削除する。
     url からファイル名を抽出して削除する。存在しない場合は何もしない。
     """
     if not url or "/static/hotel_images/" not in url:
@@ -117,10 +113,6 @@ def delete_facility_image_file(hotel_id: int, key: str, url: str) -> None:
     filename = url.split("/")[-1]
     if not filename or not filename.startswith(key):
         return
-    static_dir = _get_static_dir()
-    filepath = os.path.join(static_dir, "hotel_images", str(hotel_id), filename)
-    if os.path.exists(filepath):
-        try:
-            os.remove(filepath)
-        except OSError:
-            pass
+    s3_key = f"hotel_images/{hotel_id}/{filename}"
+    client = get_s3_client()
+    client.delete_object(Bucket=settings.S3_BUCKET, Key=s3_key)

--- a/backend/app/core/image_utils.py
+++ b/backend/app/core/image_utils.py
@@ -13,8 +13,8 @@ FACILITY_IMAGE_MAX_BYTES = 1048576
 # 圧縮時の長辺最大ピクセル
 FACILITY_IMAGE_MAX_SIDE = 1920
 
-# JPEG 圧縮品質
-JPEG_QUALITY = 85
+# WebP 圧縮品質
+WEBP_QUALITY = 85
 
 
 def _get_static_dir() -> str:
@@ -25,10 +25,22 @@ def _get_static_dir() -> str:
     )
 
 
+def _image_to_webp(img: "Image.Image", quality: int = WEBP_QUALITY) -> bytes:
+    """PIL Image を WebP バイト列に変換する。透過は RGBA で保存する。"""
+    out = BytesIO()
+    if img.mode in ("RGBA", "P"):
+        img = img.convert("RGBA")
+        img.save(out, "WEBP", quality=quality, method=6)
+    else:
+        img = img.convert("RGB")
+        img.save(out, "WEBP", quality=quality, method=6)
+    return out.getvalue()
+
+
 def compress_image(content: bytes, ext: str) -> bytes:
     """
-    画像をリサイズ・圧縮する。
-    長辺を FACILITY_IMAGE_MAX_SIDE 以下にし、JPEG 品質 85 で保存する。
+    画像をリサイズ・圧縮し、WebP バイト列で返す。
+    長辺を FACILITY_IMAGE_MAX_SIDE 以下にする。透過は RGBA のまま WebP で保存する。
     """
     try:
         from PIL import Image
@@ -36,44 +48,53 @@ def compress_image(content: bytes, ext: str) -> bytes:
         return content
 
     try:
-        img = Image.open(BytesIO(content)).convert("RGB")
+        img = Image.open(BytesIO(content))
     except Exception:
         return content
 
     w, h = img.size
-    if w <= FACILITY_IMAGE_MAX_SIDE and h <= FACILITY_IMAGE_MAX_SIDE:
-        out = BytesIO()
-        img.save(out, "JPEG", quality=JPEG_QUALITY, optimize=True)
-        return out.getvalue()
+    if w > FACILITY_IMAGE_MAX_SIDE or h > FACILITY_IMAGE_MAX_SIDE:
+        if w >= h:
+            new_w = FACILITY_IMAGE_MAX_SIDE
+            new_h = int(h * (FACILITY_IMAGE_MAX_SIDE / w))
+        else:
+            new_h = FACILITY_IMAGE_MAX_SIDE
+            new_w = int(w * (FACILITY_IMAGE_MAX_SIDE / h))
+        img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
 
-    if w >= h:
-        new_w = FACILITY_IMAGE_MAX_SIDE
-        new_h = int(h * (FACILITY_IMAGE_MAX_SIDE / w))
-    else:
-        new_h = FACILITY_IMAGE_MAX_SIDE
-        new_w = int(w * (FACILITY_IMAGE_MAX_SIDE / h))
+    return _image_to_webp(img)
 
-    img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-    out = BytesIO()
-    img.save(out, "JPEG", quality=JPEG_QUALITY, optimize=True)
-    return out.getvalue()
+
+def _convert_to_webp(content: bytes, ext: str) -> bytes:
+    """画像バイト列を WebP に変換する（リサイズなし）。"""
+    try:
+        from PIL import Image
+    except ImportError:
+        return content
+    try:
+        img = Image.open(BytesIO(content))
+        return _image_to_webp(img)
+    except Exception:
+        return content
 
 
 def save_facility_image(hotel_id: int, content: bytes, ext: str) -> tuple[str, str]:
     """
-    施設画像を保存し、(key, url) を返す。
+    施設画像を WebP 形式で保存し、(key, url) を返す。
 
-    - 1MB 超過時は圧縮してから保存する。
-    - ext は ".jpg" などドット付きで渡す。圧縮時は .jpg で保存する。
+    - 1MB 超過時はリサイズ・圧縮してから WebP で保存する。
+    - 1MB 以下も WebP に変換して保存する。
+    - ext は ".jpg" などドット付きで渡す（読み込み時の形式）。保存形式は常に .webp。
     - key: 一意キー（削除時に使用）
-    - url: 配信用 URL（例: /static/hotel_images/5/abc123.jpg）
+    - url: 配信用 URL（例: /static/hotel_images/5/abc123.webp）
     """
     if len(content) > FACILITY_IMAGE_MAX_BYTES:
         content = compress_image(content, ext)
-        ext = ".jpg"
+    else:
+        content = _convert_to_webp(content, ext)
 
     key = uuid.uuid4().hex[:12]
-    filename = f"{key}{ext}"
+    filename = f"{key}.webp"
     static_dir = _get_static_dir()
     hotel_dir = os.path.join(static_dir, "hotel_images", str(hotel_id))
     os.makedirs(hotel_dir, exist_ok=True)

--- a/backend/app/core/s3_client.py
+++ b/backend/app/core/s3_client.py
@@ -40,7 +40,7 @@ def ensure_bucket() -> None:
         client.head_bucket(Bucket=bucket)
     except client.exceptions.ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "")
-        if error_code == "404":
+        if error_code in ("404", "NoSuchBucket"):
             try:
                 client.create_bucket(Bucket=bucket)
                 logger.info("S3 bucket created: %s", bucket)

--- a/backend/app/core/s3_client.py
+++ b/backend/app/core/s3_client.py
@@ -1,0 +1,51 @@
+"""
+S3互換ストレージ（施設画像保存）用クライアント
+"""
+import logging
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_client = None
+
+
+def get_s3_client():
+    """設定から boto3 S3 クライアントを取得する（シングルトン）。"""
+    global _client
+    if _client is None:
+        if not settings.S3_ENDPOINT_URL or not settings.S3_ACCESS_KEY or not settings.S3_SECRET_KEY:
+            raise RuntimeError(
+                "S3 is not configured. Set S3_ENDPOINT_URL, S3_ACCESS_KEY, S3_SECRET_KEY in .env"
+            )
+        import boto3
+        from botocore.config import Config
+
+        _client = boto3.client(
+            "s3",
+            endpoint_url=settings.S3_ENDPOINT_URL,
+            aws_access_key_id=settings.S3_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_SECRET_KEY,
+            config=Config(signature_version="s3v4"),
+            region_name="us-east-1",
+        )
+    return _client
+
+
+def ensure_bucket() -> None:
+    """バケットが存在しなければ作成する。接続失敗時は例外を投げる。"""
+    client = get_s3_client()
+    bucket = settings.S3_BUCKET
+    try:
+        client.head_bucket(Bucket=bucket)
+    except client.exceptions.ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code == "404":
+            try:
+                client.create_bucket(Bucket=bucket)
+                logger.info("S3 bucket created: %s", bucket)
+            except Exception as create_err:
+                logger.exception("Failed to create bucket %s: %s", bucket, create_err)
+                raise
+        else:
+            raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,17 @@
 import os
+import re
 import logging
 from logging.handlers import RotatingFileHandler
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 import traceback
 
 from app.core.database import create_db_and_tables
 from app.core.config import settings
+from app.core.s3_client import get_s3_client, ensure_bucket
 from app.api import analysis, planning, creative, operation
 from app.api import admin_auth, admin_users, admin_companies, facility_auth, facility_hotels
 
@@ -75,9 +78,15 @@ async def lifespan(app: FastAPI):
     print("📊 Creating database tables...")
     create_db_and_tables()
     print("✅ Database tables created successfully")
-    
+    # S3 バケットの存在確認・作成
+    try:
+        ensure_bucket()
+        print("✅ S3 bucket ready")
+    except Exception as e:
+        logger.warning("S3 bucket check/create failed (uploads will fail until fixed): %s", e)
+
     yield
-    
+
     # 終了時の処理（必要に応じて追加）
     print("👋 Shutting down...")
 
@@ -111,6 +120,32 @@ async def log_exceptions_middleware(request: Request, call_next):
         logger.error(f"Request: {request.method} {request.url}")
         logger.error(f"Traceback:\n{traceback.format_exc()}")
         raise
+
+# 施設画像は S3 から配信（/static マウントより前に登録）
+_FACILITY_IMAGE_FILENAME_RE = re.compile(r"^[a-f0-9]{12}\.webp$")
+
+
+@app.get("/static/hotel_images/{hotel_id}/{filename}")
+async def serve_facility_image_from_s3(hotel_id: int, filename: str):
+    """施設画像を S3 から取得して返す。失敗時は 503。"""
+    if not _FACILITY_IMAGE_FILENAME_RE.match(filename):
+        raise HTTPException(status_code=404, detail="Not Found")
+    s3_key = f"hotel_images/{hotel_id}/{filename}"
+    try:
+        client = get_s3_client()
+        resp = client.get_object(Bucket=settings.S3_BUCKET, Key=s3_key)
+        body = resp["Body"]
+        return StreamingResponse(
+            body.iter_chunks(),
+            media_type="image/webp",
+        )
+    except Exception as e:
+        logger.exception("S3 get_object failed for %s: %s", s3_key, e)
+        raise HTTPException(
+            status_code=503,
+            detail="ストレージ接続に失敗しました",
+        ) from e
+
 
 # 静的ファイル配信（生成画像用）
 static_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -131,6 +131,9 @@ class Hotel(SQLModel, table=True):
     # }
     hotel_assets: dict = Field(default_factory=dict, sa_column=Column(JSON))
     
+    # 施設画像（最大10件）。各要素: key, url, description, type, order
+    facility_images: list = Field(default_factory=list, sa_column=Column(JSON))
+    
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     

--- a/backend/env.example
+++ b/backend/env.example
@@ -51,6 +51,15 @@ ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # -------------------------------------------
+# S3互換ストレージ（施設画像保存用）
+# -------------------------------------------
+# Docker 内: http://storage:9000 / ローカル: http://localhost:9000
+S3_ENDPOINT_URL=http://storage:9000
+S3_ACCESS_KEY=rustfsadmin
+S3_SECRET_KEY=rustfsadmin
+S3_BUCKET=facility-images
+
+# -------------------------------------------
 # 初期管理者設定（オプション）
 # -------------------------------------------
 INITIAL_ADMIN_EMAIL=admin@poseidon-inc.com

--- a/backend/migrations/versions/002_add_ota_text_column.py
+++ b/backend/migrations/versions/002_add_ota_text_column.py
@@ -21,14 +21,33 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """creative_assetsテーブルにota_textカラムを追加"""
-    # カラムが存在しない場合のみ追加
-    op.add_column(
-        'creative_assets',
-        sa.Column('ota_text', postgresql.JSONB(), nullable=True, server_default='{}')
-    )
+    connection = op.get_bind()
+    column_exists = connection.execute(
+        sa.text("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'creative_assets' AND column_name = 'ota_text'
+            )
+        """)
+    ).scalar()
+    if not column_exists:
+        op.add_column(
+            'creative_assets',
+            sa.Column('ota_text', postgresql.JSONB(), nullable=True, server_default='{}')
+        )
 
 
 def downgrade() -> None:
     """ota_textカラムを削除"""
-    op.drop_column('creative_assets', 'ota_text')
+    connection = op.get_bind()
+    column_exists = connection.execute(
+        sa.text("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'creative_assets' AND column_name = 'ota_text'
+            )
+        """)
+    ).scalar()
+    if column_exists:
+        op.drop_column('creative_assets', 'ota_text')
 

--- a/backend/migrations/versions/003_add_personas_column.py
+++ b/backend/migrations/versions/003_add_personas_column.py
@@ -21,12 +21,32 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """analysis_sessionsテーブルにpersonasカラムを追加"""
-    op.add_column(
-        'analysis_sessions',
-        sa.Column('personas', postgresql.JSONB(), nullable=True, server_default='[]')
-    )
+    connection = op.get_bind()
+    column_exists = connection.execute(
+        sa.text("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'analysis_sessions' AND column_name = 'personas'
+            )
+        """)
+    ).scalar()
+    if not column_exists:
+        op.add_column(
+            'analysis_sessions',
+            sa.Column('personas', postgresql.JSONB(), nullable=True, server_default='[]')
+        )
 
 
 def downgrade() -> None:
     """personasカラムを削除"""
-    op.drop_column('analysis_sessions', 'personas')
+    connection = op.get_bind()
+    column_exists = connection.execute(
+        sa.text("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'analysis_sessions' AND column_name = 'personas'
+            )
+        """)
+    ).scalar()
+    if column_exists:
+        op.drop_column('analysis_sessions', 'personas')

--- a/backend/migrations/versions/006_add_facility_images.py
+++ b/backend/migrations/versions/006_add_facility_images.py
@@ -1,0 +1,32 @@
+"""Add facility_images column to hotels
+
+Revision ID: 006_add_facility_images
+Revises: 005_add_company_model
+Create Date: 2026-02-11
+
+施設画像をJSON配列で保持するfacility_imagesカラムを追加
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '006_add_facility_images'
+down_revision: Union[str, None] = '005_add_company_model'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """hotelsテーブルにfacility_imagesカラムを追加"""
+    op.add_column(
+        'hotels',
+        sa.Column('facility_images', postgresql.JSONB(), nullable=True, server_default='[]')
+    )
+
+
+def downgrade() -> None:
+    """facility_imagesカラムを削除"""
+    op.drop_column('hotels', 'facility_images')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ bcrypt
 pandas
 openpyxl
 chardet
+Pillow
 
 # HTTP Client
 httpx

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,9 @@ openpyxl
 chardet
 Pillow
 
+# S3 compatible storage
+boto3
+
 # HTTP Client
 httpx
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,9 +7,11 @@ from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlmodel.pool import StaticPool
 from typing import Generator
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.main import app
 from app.core.database import get_session
+from app.auth.password import hash_password
 from app.models import (
     Hotel,
     AnalysisSession,
@@ -145,7 +147,8 @@ def sample_analysis_session_with_personas_fixture(session: Session, sample_hotel
                 "information_source": ["じゃらん", "Instagram"],
                 "needs": ["清潔感のある部屋", "地元食材を使った料理"],
                 "pain_points": ["平日は忙しい"],
-                "description": "テスト用ペルソナ1の説明"
+                "description": "テスト用ペルソナ1の説明",
+                "rationale": "テスト用の根拠1（分析データに基づく）",
             },
             {
                 "name": "佐藤太郎",
@@ -159,7 +162,8 @@ def sample_analysis_session_with_personas_fixture(session: Session, sample_hotel
                 "information_source": ["楽天トラベル", "口コミ"],
                 "needs": ["プライベート感", "記念日対応"],
                 "pain_points": ["混雑を避けたい"],
-                "description": "テスト用ペルソナ2の説明"
+                "description": "テスト用ペルソナ2の説明",
+                "rationale": "テスト用の根拠2（分析データに基づく）",
             },
             {
                 "name": "山田美咲",
@@ -173,8 +177,9 @@ def sample_analysis_session_with_personas_fixture(session: Session, sample_hotel
                 "information_source": ["Instagram", "TikTok"],
                 "needs": ["フォトスポット", "アメニティ充実"],
                 "pain_points": ["シフト制で予定が立てにくい"],
-                "description": "テスト用ペルソナ3の説明"
-            }
+                "description": "テスト用ペルソナ3の説明",
+                "rationale": "テスト用の根拠3（分析データに基づく）",
+            },
         ]
     )
     session.add(analysis_session)
@@ -248,6 +253,59 @@ def sample_creative_asset_fixture(session: Session, sample_marketing_plan: Marke
     session.refresh(creative_asset)
     return creative_asset
 
+
+# 施設管理者・施設画像API用フィクスチャ
+@pytest.fixture(name="facility_admin_with_hotel")
+def facility_admin_with_hotel_fixture(session: Session, sample_hotel: Hotel) -> FacilityAdmin:
+    """施設管理者と施設の紐付けを作成（施設画像APIテスト用）"""
+    admin = FacilityAdmin(
+        email="test@facility.com",
+        password_hash=hash_password("testpassword"),
+        name="テスト施設管理者",
+        is_active=True,
+    )
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    permission = FacilityAdminHotel(
+        facility_admin_id=admin.id,
+        hotel_id=sample_hotel.id,
+        role=FacilityAdminHotelRole.owner,
+    )
+    session.add(permission)
+    session.commit()
+    return admin
+
+
+@pytest.fixture(name="auth_headers")
+def auth_headers_fixture(client: TestClient, facility_admin_with_hotel: FacilityAdmin) -> dict:
+    """施設管理者の認証済みヘッダーを取得"""
+    response = client.post(
+        "/facility/auth/login",
+        json={"email": "test@facility.com", "password": "testpassword"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(name="hotel_with_facility_images")
+def hotel_with_facility_images_fixture(session: Session, sample_hotel: Hotel) -> Hotel:
+    """facility_images に1件入ったホテル（削除・更新APIテスト用）"""
+    sample_hotel.facility_images = [
+        {
+            "key": "img001",
+            "url": f"/static/hotel_images/{sample_hotel.id}/img001.jpg",
+            "description": "テスト画像",
+            "type": "exterior",
+            "order": 0,
+        }
+    ]
+    flag_modified(sample_hotel, "facility_images")
+    session.add(sample_hotel)
+    session.commit()
+    session.refresh(sample_hotel)
+    return sample_hotel
 
 
 

--- a/backend/tests/test_facility_images.py
+++ b/backend/tests/test_facility_images.py
@@ -1,0 +1,426 @@
+"""
+施設画像API（POST/DELETE/PUT /facility/hotels/{id}/images）のテスト
+"""
+
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models import Hotel, FacilityAdmin, FacilityAdminHotel, FacilityAdminHotelRole
+from app.auth.password import hash_password
+
+
+# テスト用の最小 JPEG バイト列
+MINIMAL_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
+
+
+@pytest.fixture(name="facility_admin_viewer")
+def facility_admin_viewer_fixture(session: Session, sample_hotel: Hotel) -> FacilityAdmin:
+    """viewer ロールの施設管理者（編集不可）"""
+    admin = FacilityAdmin(
+        email="viewer@facility.com",
+        password_hash=hash_password("viewerpass"),
+        name="Viewer",
+        is_active=True,
+    )
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    permission = FacilityAdminHotel(
+        facility_admin_id=admin.id,
+        hotel_id=sample_hotel.id,
+        role=FacilityAdminHotelRole.viewer,
+    )
+    session.add(permission)
+    session.commit()
+    return admin
+
+
+@pytest.fixture(name="viewer_auth_headers")
+def viewer_auth_headers_fixture(client: TestClient, facility_admin_viewer: FacilityAdmin) -> dict:
+    """viewer の認証ヘッダー"""
+    response = client.post(
+        "/facility/auth/login",
+        json={"email": "viewer@facility.com", "password": "viewerpass"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(name="other_hotel_and_admin")
+def other_hotel_and_admin_fixture(session: Session) -> tuple[Hotel, FacilityAdmin]:
+    """別施設とその owner 管理者（sample_hotel には権限なし）"""
+    hotel = Hotel(
+        name="他施設",
+        address="他住所",
+    )
+    session.add(hotel)
+    session.commit()
+    session.refresh(hotel)
+    admin = FacilityAdmin(
+        email="other@facility.com",
+        password_hash=hash_password("otherpass"),
+        name="Other",
+        is_active=True,
+    )
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    permission = FacilityAdminHotel(
+        facility_admin_id=admin.id,
+        hotel_id=hotel.id,
+        role=FacilityAdminHotelRole.owner,
+    )
+    session.add(permission)
+    session.commit()
+    return hotel, admin
+
+
+@pytest.fixture(name="other_auth_headers")
+def other_auth_headers_fixture(client: TestClient, other_hotel_and_admin: tuple[Hotel, FacilityAdmin]) -> dict:
+    """別施設管理者の認証ヘッダー"""
+    _, admin = other_hotel_and_admin
+    response = client.post(
+        "/facility/auth/login",
+        json={"email": "other@facility.com", "password": "otherpass"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(name="hotel_with_10_images")
+def hotel_with_10_images_fixture(session: Session, sample_hotel: Hotel) -> Hotel:
+    """施設画像が10枚のホテル（アップロード上限テスト用）"""
+    from sqlalchemy.orm.attributes import flag_modified
+
+    images = [
+        {
+            "key": f"img{i:03d}",
+            "url": f"/static/hotel_images/{sample_hotel.id}/img{i:03d}.jpg",
+            "description": "",
+            "type": "exterior",
+            "order": i,
+        }
+        for i in range(10)
+    ]
+    sample_hotel.facility_images = images
+    flag_modified(sample_hotel, "facility_images")
+    session.add(sample_hotel)
+    session.commit()
+    session.refresh(sample_hotel)
+    return sample_hotel
+
+
+class TestUploadFacilityImage:
+    """POST /facility/hotels/{hotel_id}/images のテスト"""
+
+    @patch("app.api.facility_hotels.save_facility_image")
+    def test_upload_success(
+        self,
+        mock_save: object,
+        client: TestClient,
+        auth_headers: dict,
+        sample_hotel: Hotel,
+    ) -> None:
+        """owner がアップロードすると 201 と FacilityImageItemResponse が返る"""
+        mock_save.return_value = ("mockkey123", f"/static/hotel_images/{sample_hotel.id}/mockkey123.jpg")
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            headers=auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior", "description": "テスト説明"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["key"] == "mockkey123"
+        assert "mockkey123" in data["url"]
+        assert data["type"] == "exterior"
+        assert data["description"] == "テスト説明"
+        assert "order" in data
+        mock_save.assert_called_once()
+
+    def test_upload_403_no_auth(
+        self,
+        client: TestClient,
+        sample_hotel: Hotel,
+    ) -> None:
+        """未認証では 401（認証エンドポイントが先に返す）"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 401
+
+    def test_upload_403_other_hotel(
+        self,
+        client: TestClient,
+        sample_hotel: Hotel,
+        other_auth_headers: dict,
+    ) -> None:
+        """他施設のみ権限がある管理者が sample_hotel にアップロードすると 403"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            headers=other_auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 403
+        assert "アクセス権限" in response.json().get("detail", "")
+
+    def test_upload_403_viewer(
+        self,
+        client: TestClient,
+        sample_hotel: Hotel,
+        viewer_auth_headers: dict,
+    ) -> None:
+        """viewer ロールでは 403"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            headers=viewer_auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 403
+        assert "編集権限" in response.json().get("detail", "")
+
+    def test_upload_404_hotel(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ) -> None:
+        """存在しない hotel_id では 403（権限チェックが先に「アクセス権限なし」を返す）"""
+        response = client.post(
+            "/facility/hotels/99999/images",
+            headers=auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 403
+
+    @patch("app.api.facility_hotels.save_facility_image")
+    def test_upload_400_max_count(
+        self,
+        mock_save: object,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_10_images: Hotel,
+    ) -> None:
+        """画像が10枚の施設に追加すると 400"""
+        response = client.post(
+            f"/facility/hotels/{hotel_with_10_images.id}/images",
+            headers=auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 400
+        assert "最大" in response.json().get("detail", "")
+        mock_save.assert_not_called()
+
+    @patch("app.api.facility_hotels.save_facility_image")
+    def test_upload_400_invalid_type(
+        self,
+        mock_save: object,
+        client: TestClient,
+        auth_headers: dict,
+        sample_hotel: Hotel,
+    ) -> None:
+        """無効な type では 400"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            headers=auth_headers,
+            files={"file": ("test.jpg", BytesIO(MINIMAL_JPEG), "image/jpeg")},
+            data={"type": "invalid_type"},
+        )
+        assert response.status_code == 400
+        assert "種別" in response.json().get("detail", "")
+        mock_save.assert_not_called()
+
+    @patch("app.api.facility_hotels.save_facility_image")
+    def test_upload_400_invalid_extension(
+        self,
+        mock_save: object,
+        client: TestClient,
+        auth_headers: dict,
+        sample_hotel: Hotel,
+    ) -> None:
+        """無効な拡張子では 400"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/images",
+            headers=auth_headers,
+            files={"file": ("test.txt", BytesIO(b"not an image"), "text/plain")},
+            data={"type": "exterior"},
+        )
+        assert response.status_code == 400
+        assert "ファイル形式" in response.json().get("detail", "")
+        mock_save.assert_not_called()
+
+
+class TestDeleteFacilityImage:
+    """DELETE /facility/hotels/{hotel_id}/images/{image_key} のテスト"""
+
+    @patch("app.api.facility_hotels.delete_facility_image_file")
+    def test_delete_success(
+        self,
+        mock_delete: object,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """削除成功で 204"""
+        response = client.delete(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            headers=auth_headers,
+        )
+        assert response.status_code == 204
+        mock_delete.assert_called_once()
+
+    def test_delete_403_no_auth(
+        self,
+        client: TestClient,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """未認証では 401（認証エンドポイントが先に返す）"""
+        response = client.delete(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+        )
+        assert response.status_code == 401
+
+    def test_delete_404_hotel(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ) -> None:
+        """存在しない hotel_id では 403（権限チェックが先に「アクセス権限なし」を返す）"""
+        response = client.delete(
+            "/facility/hotels/99999/images/img001",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+    def test_delete_404_image_key(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """存在しない image_key では 404"""
+        response = client.delete(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/nonexistent",
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+        assert "画像が見つかりません" in response.json().get("detail", "")
+
+
+class TestUpdateFacilityImage:
+    """PUT /facility/hotels/{hotel_id}/images/{image_key} のテスト"""
+
+    def test_update_success_type_only(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """type のみ更新で 200 と更新後のレスポンス"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            headers=auth_headers,
+            json={"type": "interior"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["type"] == "interior"
+        assert data["key"] == "img001"
+        assert data["description"] == "テスト画像"
+
+    def test_update_success_description_only(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """description のみ更新で 200"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            headers=auth_headers,
+            json={"description": "更新後の説明"},
+        )
+        assert response.status_code == 200
+        assert response.json()["description"] == "更新後の説明"
+
+    def test_update_success_both(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """type と description 両方更新で 200"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            headers=auth_headers,
+            json={"type": "room", "description": "部屋写真"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["type"] == "room"
+        assert data["description"] == "部屋写真"
+
+    def test_update_403_no_auth(
+        self,
+        client: TestClient,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """未認証では 401（認証エンドポイントが先に返す）"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            json={"type": "interior"},
+        )
+        assert response.status_code == 401
+
+    def test_update_404_hotel(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ) -> None:
+        """存在しない hotel_id では 403（権限チェックが先に「アクセス権限なし」を返す）"""
+        response = client.put(
+            "/facility/hotels/99999/images/img001",
+            headers=auth_headers,
+            json={"type": "interior"},
+        )
+        assert response.status_code == 403
+
+    def test_update_404_image_key(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """存在しない image_key では 404"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/nonexistent",
+            headers=auth_headers,
+            json={"type": "interior"},
+        )
+        assert response.status_code == 404
+
+    def test_update_400_invalid_type(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        hotel_with_facility_images: Hotel,
+    ) -> None:
+        """無効な type では 400"""
+        response = client.put(
+            f"/facility/hotels/{hotel_with_facility_images.id}/images/img001",
+            headers=auth_headers,
+            json={"type": "invalid_type"},
+        )
+        assert response.status_code == 400
+        assert "種別" in response.json().get("detail", "")

--- a/backend/tests/test_facility_images.py
+++ b/backend/tests/test_facility_images.py
@@ -128,7 +128,7 @@ class TestUploadFacilityImage:
         sample_hotel: Hotel,
     ) -> None:
         """owner がアップロードすると 201 と FacilityImageItemResponse が返る"""
-        mock_save.return_value = ("mockkey123", f"/static/hotel_images/{sample_hotel.id}/mockkey123.jpg")
+        mock_save.return_value = ("mockkey123", f"/static/hotel_images/{sample_hotel.id}/mockkey123.webp")
         response = client.post(
             f"/facility/hotels/{sample_hotel.id}/images",
             headers=auth_headers,

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -25,22 +25,32 @@ from app.core.image_utils import (
 class TestSaveFacilityImage:
     """save_facility_image のテスト"""
 
+    @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
     def test_save_facility_image_returns_key_and_url(self):
-        """保存成功で (key, url) が返り、ファイルが存在することを検証"""
+        """保存成功で (key, url) が返り、WebP ファイルが存在することを検証"""
+        from io import BytesIO
+
+        from PIL import Image
+
+        # PIL でデコードできる有効な小さな JPEG を使う（WebP に変換されて保存される）
+        img = Image.new("RGB", (10, 10), color="red")
+        buf = BytesIO()
+        img.save(buf, "JPEG", quality=85)
+        content = buf.getvalue()
+
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                # 最小限の JPEG 風バイト列（1バイトでも ext が .jpg なら保存される）
-                content = b"\xff\xd8\xff\xe0\x00\x10JFIF"
                 key, url = save_facility_image(1, content, ".jpg")
                 assert isinstance(key, str)
                 assert len(key) == 12
-                assert url == f"/static/hotel_images/1/{key}.jpg"
+                assert url == f"/static/hotel_images/1/{key}.webp"
                 hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
                 assert os.path.isdir(hotel_dir)
-                filepath = os.path.join(hotel_dir, f"{key}.jpg")
+                filepath = os.path.join(hotel_dir, f"{key}.webp")
                 assert os.path.isfile(filepath)
                 with open(filepath, "rb") as f:
-                    assert f.read() == content
+                    data = f.read()
+                assert data.startswith(b"RIFF") and b"WEBP" in data[:20]
 
 
 class TestDeleteFacilityImageFile:
@@ -52,7 +62,7 @@ class TestDeleteFacilityImageFile:
             hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
             os.makedirs(hotel_dir, exist_ok=True)
             key = "abc123"
-            filename = f"{key}.jpg"
+            filename = f"{key}.webp"
             filepath = os.path.join(hotel_dir, filename)
             with open(filepath, "wb") as f:
                 f.write(b"test")
@@ -67,12 +77,12 @@ class TestDeleteFacilityImageFile:
             hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
             os.makedirs(hotel_dir, exist_ok=True)
             key = "abc123"
-            filename = f"{key}.jpg"
+            filename = f"{key}.webp"
             filepath = os.path.join(hotel_dir, filename)
             with open(filepath, "wb") as f:
                 f.write(b"test")
             with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                delete_facility_image_file(1, key, "/other/path/image.jpg")
+                delete_facility_image_file(1, key, "/other/path/image.webp")
             assert os.path.isfile(filepath)
 
     def test_delete_ignores_empty_url(self):
@@ -88,7 +98,7 @@ class TestCompressImage:
 
     @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
     def test_compress_resizes_large_image(self):
-        """長辺が FACILITY_IMAGE_MAX_SIDE を超える画像はリサイズされる"""
+        """長辺が FACILITY_IMAGE_MAX_SIDE を超える画像はリサイズされ、WebP で返る"""
         from io import BytesIO
 
         from PIL import Image
@@ -101,6 +111,7 @@ class TestCompressImage:
         result = compress_image(content, ".jpg")
         assert isinstance(result, bytes)
         assert len(result) > 0
+        assert result.startswith(b"RIFF") and b"WEBP" in result[:20]
         # リサイズ後は長辺が FACILITY_IMAGE_MAX_SIDE 以下
         out_img = Image.open(BytesIO(result))
         w, h = out_img.size

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -1,10 +1,8 @@
 """
 施設画像ヘルパー（image_utils）の単体テスト
 """
-
-import os
-import tempfile
-from unittest.mock import patch
+from io import BytesIO
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,74 +21,86 @@ from app.core.image_utils import (
 
 
 class TestSaveFacilityImage:
-    """save_facility_image のテスト"""
+    """save_facility_image のテスト（S3 に保存）"""
 
     @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
     def test_save_facility_image_returns_key_and_url(self):
-        """保存成功で (key, url) が返り、WebP ファイルが存在することを検証"""
-        from io import BytesIO
-
+        """保存成功で (key, url) が返り、put_object が呼ばれることを検証"""
         from PIL import Image
 
-        # PIL でデコードできる有効な小さな JPEG を使う（WebP に変換されて保存される）
         img = Image.new("RGB", (10, 10), color="red")
         buf = BytesIO()
         img.save(buf, "JPEG", quality=85)
         content = buf.getvalue()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                key, url = save_facility_image(1, content, ".jpg")
-                assert isinstance(key, str)
-                assert len(key) == 12
-                assert url == f"/static/hotel_images/1/{key}.webp"
-                hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
-                assert os.path.isdir(hotel_dir)
-                filepath = os.path.join(hotel_dir, f"{key}.webp")
-                assert os.path.isfile(filepath)
-                with open(filepath, "rb") as f:
-                    data = f.read()
-                assert data.startswith(b"RIFF") and b"WEBP" in data[:20]
+        mock_client = MagicMock()
+        with patch("app.core.image_utils.get_s3_client", return_value=mock_client), patch(
+            "app.core.image_utils.settings"
+        ) as mock_settings:
+            mock_settings.S3_BUCKET = "facility-images"
+            key, url = save_facility_image(1, content, ".jpg")
+
+        assert isinstance(key, str)
+        assert len(key) == 12
+        assert url == f"/static/hotel_images/1/{key}.webp"
+        mock_client.put_object.assert_called_once()
+        call_kw = mock_client.put_object.call_args.kwargs
+        assert call_kw["Bucket"] == "facility-images"
+        assert call_kw["Key"] == f"hotel_images/1/{key}.webp"
+        assert call_kw["ContentType"] == "image/webp"
+        body = call_kw["Body"]
+        assert body.startswith(b"RIFF") and b"WEBP" in body[:20]
+
+    @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
+    def test_save_facility_image_raises_on_s3_error(self):
+        """S3 put_object が失敗した場合に例外が伝播することを検証"""
+        from PIL import Image
+
+        img = Image.new("RGB", (10, 10), color="red")
+        buf = BytesIO()
+        img.save(buf, "JPEG", quality=85)
+        content = buf.getvalue()
+
+        mock_client = MagicMock()
+        mock_client.put_object.side_effect = Exception("connection failed")
+        with patch("app.core.image_utils.get_s3_client", return_value=mock_client):
+            with pytest.raises(Exception, match="connection failed"):
+                save_facility_image(1, content, ".jpg")
 
 
 class TestDeleteFacilityImageFile:
-    """delete_facility_image_file のテスト"""
+    """delete_facility_image_file のテスト（S3 から削除）"""
 
-    def test_delete_removes_file(self):
-        """正しい url の場合、ファイルが削除されることを検証"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
-            os.makedirs(hotel_dir, exist_ok=True)
-            key = "abc123"
-            filename = f"{key}.webp"
-            filepath = os.path.join(hotel_dir, filename)
-            with open(filepath, "wb") as f:
-                f.write(b"test")
-            url = f"/static/hotel_images/1/{filename}"
-            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                delete_facility_image_file(1, key, url)
-            assert not os.path.isfile(filepath)
+    def test_delete_calls_s3_delete_object(self):
+        """正しい url の場合、delete_object が呼ばれることを検証"""
+        key = "abc123"
+        filename = f"{key}.webp"
+        url = f"/static/hotel_images/1/{filename}"
+        mock_client = MagicMock()
+        with patch("app.core.image_utils.get_s3_client", return_value=mock_client), patch(
+            "app.core.image_utils.settings"
+        ) as mock_settings:
+            mock_settings.S3_BUCKET = "facility-images"
+            delete_facility_image_file(1, key, url)
+        mock_client.delete_object.assert_called_once_with(
+            Bucket="facility-images",
+            Key=f"hotel_images/1/{filename}",
+        )
 
     def test_delete_ignores_invalid_url(self):
-        """url が /static/hotel_images/ を含まない場合は削除されない"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
-            os.makedirs(hotel_dir, exist_ok=True)
-            key = "abc123"
-            filename = f"{key}.webp"
-            filepath = os.path.join(hotel_dir, filename)
-            with open(filepath, "wb") as f:
-                f.write(b"test")
-            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                delete_facility_image_file(1, key, "/other/path/image.webp")
-            assert os.path.isfile(filepath)
+        """url が /static/hotel_images/ を含まない場合は delete_object を呼ばない"""
+        mock_client = MagicMock()
+        with patch("app.core.image_utils.get_s3_client", return_value=mock_client):
+            delete_facility_image_file(1, "abc123", "/other/path/image.webp")
+        mock_client.delete_object.assert_not_called()
 
     def test_delete_ignores_empty_url(self):
         """url が空の場合は何もしない"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
-                delete_facility_image_file(1, "abc", "")
-                delete_facility_image_file(1, "abc", None)  # type: ignore
+        mock_client = MagicMock()
+        with patch("app.core.image_utils.get_s3_client", return_value=mock_client):
+            delete_facility_image_file(1, "abc", "")
+            delete_facility_image_file(1, "abc", None)  # type: ignore
+        mock_client.delete_object.assert_not_called()
 
 
 class TestCompressImage:
@@ -99,11 +109,8 @@ class TestCompressImage:
     @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
     def test_compress_resizes_large_image(self):
         """長辺が FACILITY_IMAGE_MAX_SIDE を超える画像はリサイズされ、WebP で返る"""
-        from io import BytesIO
-
         from PIL import Image
 
-        # 2000x1000 の画像を生成（長辺 2000 > 1920）
         img = Image.new("RGB", (2000, 1000), color="red")
         buf = BytesIO()
         img.save(buf, "JPEG", quality=90)
@@ -112,7 +119,6 @@ class TestCompressImage:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert result.startswith(b"RIFF") and b"WEBP" in result[:20]
-        # リサイズ後は長辺が FACILITY_IMAGE_MAX_SIDE 以下
         out_img = Image.open(BytesIO(result))
         w, h = out_img.size
         assert max(w, h) <= FACILITY_IMAGE_MAX_SIDE

--- a/backend/tests/test_image_utils.py
+++ b/backend/tests/test_image_utils.py
@@ -1,0 +1,107 @@
+"""
+施設画像ヘルパー（image_utils）の単体テスト
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from PIL import Image  # noqa: F401
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
+
+from app.core.image_utils import (
+    save_facility_image,
+    delete_facility_image_file,
+    compress_image,
+    FACILITY_IMAGE_MAX_SIDE,
+)
+
+
+class TestSaveFacilityImage:
+    """save_facility_image のテスト"""
+
+    def test_save_facility_image_returns_key_and_url(self):
+        """保存成功で (key, url) が返り、ファイルが存在することを検証"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
+                # 最小限の JPEG 風バイト列（1バイトでも ext が .jpg なら保存される）
+                content = b"\xff\xd8\xff\xe0\x00\x10JFIF"
+                key, url = save_facility_image(1, content, ".jpg")
+                assert isinstance(key, str)
+                assert len(key) == 12
+                assert url == f"/static/hotel_images/1/{key}.jpg"
+                hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
+                assert os.path.isdir(hotel_dir)
+                filepath = os.path.join(hotel_dir, f"{key}.jpg")
+                assert os.path.isfile(filepath)
+                with open(filepath, "rb") as f:
+                    assert f.read() == content
+
+
+class TestDeleteFacilityImageFile:
+    """delete_facility_image_file のテスト"""
+
+    def test_delete_removes_file(self):
+        """正しい url の場合、ファイルが削除されることを検証"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
+            os.makedirs(hotel_dir, exist_ok=True)
+            key = "abc123"
+            filename = f"{key}.jpg"
+            filepath = os.path.join(hotel_dir, filename)
+            with open(filepath, "wb") as f:
+                f.write(b"test")
+            url = f"/static/hotel_images/1/{filename}"
+            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
+                delete_facility_image_file(1, key, url)
+            assert not os.path.isfile(filepath)
+
+    def test_delete_ignores_invalid_url(self):
+        """url が /static/hotel_images/ を含まない場合は削除されない"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hotel_dir = os.path.join(tmpdir, "hotel_images", "1")
+            os.makedirs(hotel_dir, exist_ok=True)
+            key = "abc123"
+            filename = f"{key}.jpg"
+            filepath = os.path.join(hotel_dir, filename)
+            with open(filepath, "wb") as f:
+                f.write(b"test")
+            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
+                delete_facility_image_file(1, key, "/other/path/image.jpg")
+            assert os.path.isfile(filepath)
+
+    def test_delete_ignores_empty_url(self):
+        """url が空の場合は何もしない"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("app.core.image_utils._get_static_dir", return_value=tmpdir):
+                delete_facility_image_file(1, "abc", "")
+                delete_facility_image_file(1, "abc", None)  # type: ignore
+
+
+class TestCompressImage:
+    """compress_image のテスト（PIL がある場合のみ）"""
+
+    @pytest.mark.skipif(not HAS_PIL, reason="PIL not installed")
+    def test_compress_resizes_large_image(self):
+        """長辺が FACILITY_IMAGE_MAX_SIDE を超える画像はリサイズされる"""
+        from io import BytesIO
+
+        from PIL import Image
+
+        # 2000x1000 の画像を生成（長辺 2000 > 1920）
+        img = Image.new("RGB", (2000, 1000), color="red")
+        buf = BytesIO()
+        img.save(buf, "JPEG", quality=90)
+        content = buf.getvalue()
+        result = compress_image(content, ".jpg")
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        # リサイズ後は長辺が FACILITY_IMAGE_MAX_SIDE 以下
+        out_img = Image.open(BytesIO(result))
+        w, h = out_img.size
+        assert max(w, h) <= FACILITY_IMAGE_MAX_SIDE

--- a/backend/tests/test_persona.py
+++ b/backend/tests/test_persona.py
@@ -12,51 +12,10 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 from unittest.mock import patch, AsyncMock
 
-from app.models import Hotel, AnalysisSession, FacilityAdmin, FacilityAdminHotel, FacilityAdminHotelRole
-from app.auth.password import hash_password
+from app.models import Hotel, AnalysisSession, FacilityAdmin
 
 
-# ============================================
-# フィクスチャ
-# ============================================
-
-@pytest.fixture(name="facility_admin_with_hotel")
-def facility_admin_with_hotel_fixture(session: Session, sample_hotel: Hotel):
-    """施設管理者と施設の紐付けを作成"""
-    # 施設管理者を作成
-    admin = FacilityAdmin(
-        email="test@facility.com",
-        password_hash=hash_password("testpassword"),
-        name="テスト施設管理者",
-        is_active=True
-    )
-    session.add(admin)
-    session.commit()
-    session.refresh(admin)
-    
-    # 施設との紐付けを作成
-    permission = FacilityAdminHotel(
-        facility_admin_id=admin.id,
-        hotel_id=sample_hotel.id,
-        role=FacilityAdminHotelRole.owner
-    )
-    session.add(permission)
-    session.commit()
-    
-    return admin
-
-
-@pytest.fixture(name="auth_headers")
-def auth_headers_fixture(client: TestClient, facility_admin_with_hotel: FacilityAdmin):
-    """認証済みヘッダーを取得"""
-    response = client.post(
-        "/facility/auth/login",
-        json={"email": "test@facility.com", "password": "testpassword"}
-    )
-    assert response.status_code == 200
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
-
+# facility_admin_with_hotel, auth_headers は conftest.py で定義
 
 # ============================================
 # ペルソナ取得テスト
@@ -86,7 +45,7 @@ def test_get_personas_with_data(
     session: Session
 ):
     """ペルソナがある状態で取得"""
-    # ペルソナ付きの分析セッションを作成
+    # ペルソナ付きの分析セッションを作成（Persona スキーマは rationale 必須）
     analysis_session = AnalysisSession(
         hotel_id=sample_hotel.id,
         csv_statistics={"total_records": 100},
@@ -103,9 +62,10 @@ def test_get_personas_with_data(
                 "information_source": ["じゃらん"],
                 "needs": ["清潔感"],
                 "pain_points": ["忙しい"],
-                "description": "テスト"
+                "description": "テスト",
+                "rationale": "テスト用の根拠",
             }
-        ]
+        ],
     )
     session.add(analysis_session)
     session.commit()
@@ -149,7 +109,7 @@ def test_generate_personas_success(
     sample_analysis_session: AnalysisSession
 ):
     """ペルソナ生成成功"""
-    # モックのレスポンスを設定
+    # モックのレスポンスを設定（Persona スキーマは rationale 必須）
     mock_generate.return_value = [
         {
             "name": "田中花子",
@@ -163,7 +123,8 @@ def test_generate_personas_success(
             "information_source": ["じゃらん", "Instagram"],
             "needs": ["清潔感", "おもてなし"],
             "pain_points": ["平日は忙しい"],
-            "description": "テストペルソナ"
+            "description": "テストペルソナ",
+            "rationale": "テスト用の根拠1",
         },
         {
             "name": "佐藤太郎",
@@ -177,7 +138,8 @@ def test_generate_personas_success(
             "information_source": ["楽天トラベル"],
             "needs": ["プライベート感"],
             "pain_points": ["混雑を避けたい"],
-            "description": "テストペルソナ2"
+            "description": "テストペルソナ2",
+            "rationale": "テスト用の根拠2",
         },
         {
             "name": "山田美咲",
@@ -191,8 +153,9 @@ def test_generate_personas_success(
             "information_source": ["Instagram", "TikTok"],
             "needs": ["フォトスポット"],
             "pain_points": ["シフト制"],
-            "description": "テストペルソナ3"
-        }
+            "description": "テストペルソナ3",
+            "rationale": "テスト用の根拠3",
+        },
     ]
     
     response = client.post(
@@ -234,7 +197,7 @@ def test_edit_persona_invalid_index(
     session: Session
 ):
     """無効なインデックスでペルソナを修正しようとする"""
-    # ペルソナ付きの分析セッションを作成
+    # ペルソナ付きの分析セッションを作成（Persona スキーマは rationale 必須）
     analysis_session = AnalysisSession(
         hotel_id=sample_hotel.id,
         csv_statistics={"total_records": 100},
@@ -251,9 +214,10 @@ def test_edit_persona_invalid_index(
                 "information_source": ["じゃらん"],
                 "needs": ["清潔感"],
                 "pain_points": ["忙しい"],
-                "description": "テスト"
+                "description": "テスト",
+                "rationale": "テスト用の根拠",
             }
-        ]
+        ],
     )
     session.add(analysis_session)
     session.commit()
@@ -276,7 +240,7 @@ def test_edit_persona_success(
     session: Session
 ):
     """ペルソナ修正成功"""
-    # ペルソナ付きの分析セッションを作成
+    # ペルソナ付きの分析セッションを作成（Persona スキーマは rationale 必須）
     analysis_session = AnalysisSession(
         hotel_id=sample_hotel.id,
         csv_statistics={"total_records": 100},
@@ -293,14 +257,15 @@ def test_edit_persona_success(
                 "information_source": ["じゃらん"],
                 "needs": ["清潔感"],
                 "pain_points": ["忙しい"],
-                "description": "テスト"
+                "description": "テスト",
+                "rationale": "テスト用の根拠",
             }
-        ]
+        ],
     )
     session.add(analysis_session)
     session.commit()
-    
-    # モックのレスポンスを設定（年齢を変更）
+
+    # モックのレスポンスを設定（年齢を変更。Persona スキーマは rationale 必須）
     mock_edit.return_value = {
         "name": "田中花子",
         "age_range": "20代前半",
@@ -313,7 +278,8 @@ def test_edit_persona_success(
         "information_source": ["Instagram"],
         "needs": ["フォトスポット"],
         "pain_points": ["予算が限られている"],
-        "description": "若い世代に変更されたペルソナ"
+        "description": "若い世代に変更されたペルソナ",
+        "rationale": "テスト用の根拠（修正後）",
     }
     
     response = client.put(
@@ -364,7 +330,7 @@ def test_persona_schema():
     """Personaスキーマのバリデーション"""
     from app.schemas.analysis import Persona
     
-    # 正常なデータ
+    # 正常なデータ（Persona スキーマは rationale 必須）
     valid_persona = Persona(
         name="田中花子",
         age_range="30代",
@@ -377,7 +343,8 @@ def test_persona_schema():
         information_source=["じゃらん"],
         needs=["清潔感"],
         pain_points=["忙しい"],
-        description="テスト"
+        description="テスト",
+        rationale="テスト用の根拠（分析データに基づく）",
     )
     assert valid_persona.name == "田中花子"
     assert valid_persona.location == "東京都世田谷区"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./backend/.env
     depends_on:
       - db
+      - storage
 
   frontend:
     build:
@@ -38,5 +39,24 @@ services:
     ports:
       - "5432:5432"
 
+  storage:
+    image: rustfs/rustfs:latest
+    volumes:
+      - rustfs_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
+      - RUSTFS_CONSOLE_ENABLE=true
+    command: >
+      --address :9000
+      --console-enable
+      --access-key rustfsadmin
+      --secret-key rustfsadmin
+      /data
+
 volumes:
   postgres_data:
+  rustfs_data:

--- a/frontend/src/app/facility/hotels/[hotelId]/images/page.tsx
+++ b/frontend/src/app/facility/hotels/[hotelId]/images/page.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  facilityApi,
+  HotelResponse,
+  FacilityImageItem,
+  ApiError,
+} from "@/lib/api";
+import {
+  ArrowLeft,
+  Image as ImageIcon,
+  Upload,
+  Trash2,
+  Loader2,
+} from "lucide-react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+const FACILITY_IMAGE_TYPE_LABELS: Record<string, string> = {
+  panorama: "全景",
+  room: "部屋",
+  bath: "風呂",
+  cuisine: "料理",
+  lobby: "ロビー",
+  restaurant: "レストラン",
+  sightseeing: "周辺観光地",
+  staff: "スタッフ",
+  other: "その他",
+};
+
+const FACILITY_IMAGE_TYPES = [
+  "panorama",
+  "room",
+  "bath",
+  "cuisine",
+  "lobby",
+  "restaurant",
+  "sightseeing",
+  "staff",
+  "other",
+];
+
+const MAX_IMAGES = 10;
+
+export default function FacilityHotelImagesPage() {
+  const params = useParams();
+  const router = useRouter();
+  const hotelId = Number(params.hotelId);
+
+  const [hotel, setHotel] = useState<HotelResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [uploadType, setUploadType] = useState<string>("other");
+  const [uploadDescription, setUploadDescription] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<{
+    current: number;
+    total: number;
+    message: string;
+  } | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const [deletingKey, setDeletingKey] = useState<string | null>(null);
+
+  const loadHotel = useCallback(async () => {
+    if (!hotelId || isNaN(hotelId)) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await facilityApi.getHotel(hotelId);
+      setHotel(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail);
+      } else {
+        setError("施設情報の取得に失敗しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [hotelId]);
+
+  useEffect(() => {
+    loadHotel();
+  }, [loadHotel]);
+
+  const images = hotel?.facility_images ?? [];
+  const sortedImages = [...images].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0)
+  );
+  const canAddMore = images.length < MAX_IMAGES;
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0 || !hotel || !canAddMore) return;
+    const fileArray = Array.from(files).filter((f) =>
+      /\.(jpe?g|png|webp)$/i.test(f.name)
+    );
+    if (fileArray.length === 0) {
+      setUploadError("画像ファイル（jpg, png, webp）を選んでください");
+      return;
+    }
+    const remaining = MAX_IMAGES - images.length;
+    const toUpload = fileArray.slice(0, remaining);
+    setUploading(true);
+    setUploadError(null);
+    setUploadProgress({ current: 0, total: toUpload.length, message: "準備中..." });
+
+    let successCount = 0;
+    for (let i = 0; i < toUpload.length; i++) {
+      setUploadProgress({
+        current: i + 1,
+        total: toUpload.length,
+        message: `${i + 1}枚目を登録中…`,
+      });
+      try {
+        await facilityApi.uploadHotelImage(
+          hotelId,
+          toUpload[i],
+          uploadType,
+          uploadDescription || undefined
+        );
+        successCount++;
+      } catch (err) {
+        const msg =
+          err instanceof ApiError ? err.detail : "登録に失敗しました";
+        setUploadError(`${i + 1}枚目: ${msg}`);
+        setUploadProgress(null);
+        setUploading(false);
+        await loadHotel();
+        return;
+      }
+    }
+
+    setUploadProgress({
+      current: toUpload.length,
+      total: toUpload.length,
+      message: `${successCount}枚登録しました`,
+    });
+    setUploading(false);
+    setTimeout(() => setUploadProgress(null), 2000);
+    await loadHotel();
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!uploading && canAddMore) handleFiles(e.dataTransfer.files);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleDelete = async (item: FacilityImageItem) => {
+    if (!hotel) return;
+    setDeletingKey(item.key);
+    try {
+      await facilityApi.deleteHotelImage(hotelId, item.key);
+      await loadHotel();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail);
+      }
+    } finally {
+      setDeletingKey(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-10 w-10 animate-spin text-teal-600" />
+      </div>
+    );
+  }
+
+  if (error || !hotel) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Link
+          href="/facility/hotels"
+          className="inline-flex items-center text-sm text-teal-600 hover:text-teal-700 mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          施設一覧に戻る
+        </Link>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          {error ?? "施設が見つかりません"}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <Link
+        href="/facility/hotels"
+        className="inline-flex items-center text-sm text-teal-600 hover:text-teal-700 mb-6"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" />
+        施設一覧に戻る
+      </Link>
+
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">
+        {hotel.name} の写真
+      </h1>
+      <p className="text-sm text-gray-500 mb-6">
+        施設の写真を追加・削除できます。最大{MAX_IMAGES}枚まで登録できます。
+      </p>
+
+      {/* 既存画像一覧 */}
+      {sortedImages.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-lg font-medium text-gray-900 mb-3">
+            登録済みの写真（{sortedImages.length}枚）
+          </h2>
+          <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {sortedImages.map((item) => (
+              <li
+                key={item.key}
+                className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
+              >
+                <div className="aspect-video bg-gray-100 relative">
+                  <img
+                    src={`${API_BASE_URL}${item.url}`}
+                    alt={item.description || item.type}
+                    className="w-full h-full object-cover"
+                  />
+                  {(hotel.role === "owner" || hotel.role === "editor") && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(item)}
+                      disabled={deletingKey === item.key}
+                      className="absolute top-2 right-2 p-1.5 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
+                      title="削除"
+                    >
+                      {deletingKey === item.key ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </button>
+                  )}
+                </div>
+                <div className="p-2 text-xs">
+                  <span className="font-medium text-gray-700">
+                    {FACILITY_IMAGE_TYPE_LABELS[item.type] ?? item.type}
+                  </span>
+                  {item.description && (
+                    <p className="text-gray-500 mt-0.5 truncate">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* アップロード（owner/editor かつ 10枚未満のとき） */}
+      {(hotel.role === "owner" || hotel.role === "editor") && (
+        <section className="mb-8">
+          <h2 className="text-lg font-medium text-gray-900 mb-3">
+            写真を追加
+          </h2>
+          {canAddMore ? (
+            <>
+              <div className="flex flex-wrap gap-4 mb-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    種別
+                  </label>
+                  <select
+                    value={uploadType}
+                    onChange={(e) => setUploadType(e.target.value)}
+                    disabled={uploading}
+                    className="block w-full min-w-[160px] px-3 py-2 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 disabled:opacity-50"
+                  >
+                    {FACILITY_IMAGE_TYPES.map((t) => (
+                      <option key={t} value={t}>
+                        {FACILITY_IMAGE_TYPE_LABELS[t]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex-1 min-w-[200px]">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    説明（任意）
+                  </label>
+                  <input
+                    type="text"
+                    value={uploadDescription}
+                    onChange={(e) => setUploadDescription(e.target.value)}
+                    disabled={uploading}
+                    placeholder="例：客室から見た庭園"
+                    className="block w-full px-3 py-2 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 disabled:opacity-50"
+                  />
+                </div>
+              </div>
+
+              <div
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center bg-gray-50 hover:border-teal-400 transition-colors"
+              >
+                <input
+                  type="file"
+                  id="facility-image-upload"
+                  accept=".jpg,.jpeg,.png,.webp"
+                  multiple
+                  disabled={uploading}
+                  onChange={(e) => handleFiles(e.target.files)}
+                  className="hidden"
+                />
+                <label
+                  htmlFor="facility-image-upload"
+                  className="cursor-pointer flex flex-col items-center"
+                >
+                  <Upload className="h-12 w-12 text-gray-400 mb-2" />
+                  <p className="text-sm font-medium text-gray-700 mb-1">
+                    ここに写真をドラッグするか、下のボタンで選んでください
+                  </p>
+                  <p className="text-xs text-gray-500 mb-4">
+                    jpg, png, webp（複数選択可・最大{MAX_IMAGES - images.length}枚まで）
+                  </p>
+                  <span className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50">
+                    ファイルを選ぶ
+                  </span>
+                </label>
+              </div>
+
+              {uploadProgress && (
+                <div className="mt-4 flex items-center gap-2 text-sm text-gray-700">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>
+                    {uploadProgress.current} / {uploadProgress.total} 枚目 —{" "}
+                    {uploadProgress.message}
+                  </span>
+                </div>
+              )}
+              {uploadError && (
+                <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                  {uploadError}
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">
+              登録できる写真は最大{MAX_IMAGES}枚です。追加するには既存の写真を削除してください。
+            </p>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/facility/hotels/[hotelId]/images/page.tsx
+++ b/frontend/src/app/facility/hotels/[hotelId]/images/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
   facilityApi,
@@ -11,16 +11,19 @@ import {
 } from "@/lib/api";
 import {
   ArrowLeft,
-  Image as ImageIcon,
   Upload,
   Trash2,
   Loader2,
+  X,
 } from "lucide-react";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+// 種別ラベル（panorama は後方互換で施設外観として表示）
 const FACILITY_IMAGE_TYPE_LABELS: Record<string, string> = {
-  panorama: "全景",
+  exterior: "施設外観",
+  interior: "施設内観",
+  panorama: "施設外観",
   room: "部屋",
   bath: "風呂",
   cuisine: "料理",
@@ -32,7 +35,8 @@ const FACILITY_IMAGE_TYPE_LABELS: Record<string, string> = {
 };
 
 const FACILITY_IMAGE_TYPES = [
-  "panorama",
+  "exterior",
+  "interior",
   "room",
   "bath",
   "cuisine",
@@ -45,17 +49,170 @@ const FACILITY_IMAGE_TYPES = [
 
 const MAX_IMAGES = 10;
 
+type PendingItem = {
+  id: string;
+  file: File;
+  type: string;
+  description: string;
+  previewUrl: string;
+};
+
+function generateId() {
+  return `pending-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+type ImageLightboxModalProps = {
+  item: FacilityImageItem;
+  apiBaseUrl: string;
+  typeLabels: Record<string, string>;
+  types: string[];
+  canEdit: boolean;
+  onClose: () => void;
+  onSave: (type: string, description: string) => void;
+  saving: boolean;
+};
+
+function ImageLightboxModal({
+  item,
+  apiBaseUrl,
+  typeLabels,
+  types,
+  canEdit,
+  onClose,
+  onSave,
+  saving,
+}: ImageLightboxModalProps) {
+  const normalizedType =
+    item.type === "panorama" ? "exterior" : item.type;
+  const [editType, setEditType] = useState(normalizedType);
+  const [editDescription, setEditDescription] = useState(
+    item.description ?? ""
+  );
+
+  useEffect(() => {
+    setEditType(item.type === "panorama" ? "exterior" : item.type);
+    setEditDescription(item.description ?? "");
+  }, [item.type, item.description]);
+
+  const hasChange =
+    editType !== item.type || editDescription !== (item.description ?? "");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="relative bg-gray-900 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-auto flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-2 right-2 z-10 p-2 text-white/80 hover:text-white rounded-full bg-black/40 hover:bg-black/60"
+          title="閉じる"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="flex-1 flex items-center justify-center p-6 min-h-0">
+          <img
+            src={`${apiBaseUrl}${item.url}`}
+            alt={item.description || item.type}
+            className="max-w-full max-h-[70vh] w-auto h-auto object-contain"
+          />
+        </div>
+
+        <div className="p-4 bg-white border-t border-gray-200 rounded-b-lg space-y-4">
+          {canEdit ? (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  種別
+                </label>
+                <select
+                  value={editType}
+                  onChange={(e) => setEditType(e.target.value)}
+                  disabled={saving}
+                  className="block w-full max-w-xs px-3 py-2 text-sm border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+                >
+                  {types.map((t) => (
+                    <option key={t} value={t}>
+                      {typeLabels[t] ?? t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  説明
+                </label>
+                <input
+                  type="text"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  disabled={saving}
+                  placeholder="説明（任意）"
+                  className="block w-full px-3 py-2 text-sm border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+                />
+              </div>
+              <div className="flex gap-3">
+                {hasChange && (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await onSave(editType, editDescription);
+                    }}
+                    disabled={saving}
+                    className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-lg text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50"
+                  >
+                    {saving ? (
+                      <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    ) : null}
+                    保存
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
+                >
+                  閉じる
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-sm font-medium text-gray-700">
+                {typeLabels[item.type] ?? item.type}
+              </p>
+              {item.description && (
+                <p className="text-sm text-gray-500">{item.description}</p>
+              )}
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
+              >
+                閉じる
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function FacilityHotelImagesPage() {
   const params = useParams();
-  const router = useRouter();
   const hotelId = Number(params.hotelId);
 
   const [hotel, setHotel] = useState<HotelResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [uploadType, setUploadType] = useState<string>("other");
-  const [uploadDescription, setUploadDescription] = useState("");
+  const [pendingItems, setPendingItems] = useState<PendingItem[]>([]);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<{
     current: number;
@@ -65,6 +222,14 @@ export default function FacilityHotelImagesPage() {
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [deleteConfirmItem, setDeleteConfirmItem] =
+    useState<FacilityImageItem | null>(null);
+  const [lightboxItem, setLightboxItem] =
+    useState<FacilityImageItem | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const pendingItemsRef = useRef<PendingItem[]>([]);
+  pendingItemsRef.current = pendingItems;
 
   const loadHotel = useCallback(async () => {
     if (!hotelId || isNaN(hotelId)) return;
@@ -88,40 +253,83 @@ export default function FacilityHotelImagesPage() {
     loadHotel();
   }, [loadHotel]);
 
+  // アンマウント時に保留中の object URL を revoke
+  useEffect(() => {
+    return () => {
+      pendingItemsRef.current.forEach((item) =>
+        URL.revokeObjectURL(item.previewUrl)
+      );
+    };
+  }, []);
+
   const images = hotel?.facility_images ?? [];
   const sortedImages = [...images].sort(
     (a, b) => (a.order ?? 0) - (b.order ?? 0)
   );
   const canAddMore = images.length < MAX_IMAGES;
+  const remainingSlots = MAX_IMAGES - images.length - pendingItems.length;
 
-  const handleFiles = async (files: FileList | null) => {
-    if (!files || files.length === 0 || !hotel || !canAddMore) return;
+  const addFilesToPending = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
     const fileArray = Array.from(files).filter((f) =>
       /\.(jpe?g|png|webp)$/i.test(f.name)
     );
-    if (fileArray.length === 0) {
-      setUploadError("画像ファイル（jpg, png, webp）を選んでください");
-      return;
-    }
-    const remaining = MAX_IMAGES - images.length;
-    const toUpload = fileArray.slice(0, remaining);
+    const newItems: PendingItem[] = fileArray
+      .slice(0, Math.max(0, remainingSlots))
+      .map((file) => ({
+        id: generateId(),
+        file,
+        type: FACILITY_IMAGE_TYPES[0],
+        description: "",
+        previewUrl: URL.createObjectURL(file),
+      }));
+    setPendingItems((prev) => [...prev, ...newItems]);
+    setUploadError(null);
+  };
+
+  const removePending = (id: string) => {
+    setPendingItems((prev) => {
+      const item = prev.find((p) => p.id === id);
+      if (item) URL.revokeObjectURL(item.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  };
+
+  const updatePendingItem = (
+    id: string,
+    updates: { type?: string; description?: string }
+  ) => {
+    setPendingItems((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, ...updates } : p
+      )
+    );
+  };
+
+  const handleUploadAll = async () => {
+    if (pendingItems.length === 0 || !hotel) return;
     setUploading(true);
     setUploadError(null);
-    setUploadProgress({ current: 0, total: toUpload.length, message: "準備中..." });
+    setUploadProgress({
+      current: 0,
+      total: pendingItems.length,
+      message: "準備中...",
+    });
 
     let successCount = 0;
-    for (let i = 0; i < toUpload.length; i++) {
+    for (let i = 0; i < pendingItems.length; i++) {
+      const item = pendingItems[i];
       setUploadProgress({
         current: i + 1,
-        total: toUpload.length,
+        total: pendingItems.length,
         message: `${i + 1}枚目を登録中…`,
       });
       try {
         await facilityApi.uploadHotelImage(
           hotelId,
-          toUpload[i],
-          uploadType,
-          uploadDescription || undefined
+          item.file,
+          item.type,
+          item.description || undefined
         );
         successCount++;
       } catch (err) {
@@ -135,9 +343,11 @@ export default function FacilityHotelImagesPage() {
       }
     }
 
+    pendingItems.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    setPendingItems([]);
     setUploadProgress({
-      current: toUpload.length,
-      total: toUpload.length,
+      current: pendingItems.length,
+      total: pendingItems.length,
       message: `${successCount}枚登録しました`,
     });
     setUploading(false);
@@ -147,7 +357,7 @@ export default function FacilityHotelImagesPage() {
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    if (!uploading && canAddMore) handleFiles(e.dataTransfer.files);
+    if (!uploading && canAddMore) addFilesToPending(e.dataTransfer.files);
   };
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -156,6 +366,7 @@ export default function FacilityHotelImagesPage() {
 
   const handleDelete = async (item: FacilityImageItem) => {
     if (!hotel) return;
+    setDeleteConfirmItem(null);
     setDeletingKey(item.key);
     try {
       await facilityApi.deleteHotelImage(hotelId, item.key);
@@ -166,6 +377,27 @@ export default function FacilityHotelImagesPage() {
       }
     } finally {
       setDeletingKey(null);
+    }
+  };
+
+  const handleSaveImageMeta = async (
+    item: FacilityImageItem,
+    type: string,
+    description: string
+  ) => {
+    setSavingKey(item.key);
+    try {
+      await facilityApi.updateHotelImage(hotelId, item.key, {
+        type,
+        description,
+      });
+      await loadHotel();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail);
+      }
+    } finally {
+      setSavingKey(null);
     }
   };
 
@@ -211,7 +443,7 @@ export default function FacilityHotelImagesPage() {
         施設の写真を追加・削除できます。最大{MAX_IMAGES}枚まで登録できます。
       </p>
 
-      {/* 既存画像一覧 */}
+      {/* 登録済み画像一覧（インライン編集あり） */}
       {sortedImages.length > 0 && (
         <section className="mb-8">
           <h2 className="text-lg font-medium text-gray-900 mb-3">
@@ -219,49 +451,81 @@ export default function FacilityHotelImagesPage() {
           </h2>
           <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
             {sortedImages.map((item) => (
-              <li
+              <RegisteredImageCard
                 key={item.key}
-                className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
-              >
-                <div className="aspect-video bg-gray-100 relative">
-                  <img
-                    src={`${API_BASE_URL}${item.url}`}
-                    alt={item.description || item.type}
-                    className="w-full h-full object-cover"
-                  />
-                  {(hotel.role === "owner" || hotel.role === "editor") && (
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(item)}
-                      disabled={deletingKey === item.key}
-                      className="absolute top-2 right-2 p-1.5 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
-                      title="削除"
-                    >
-                      {deletingKey === item.key ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="h-4 w-4" />
-                      )}
-                    </button>
-                  )}
-                </div>
-                <div className="p-2 text-xs">
-                  <span className="font-medium text-gray-700">
-                    {FACILITY_IMAGE_TYPE_LABELS[item.type] ?? item.type}
-                  </span>
-                  {item.description && (
-                    <p className="text-gray-500 mt-0.5 truncate">
-                      {item.description}
-                    </p>
-                  )}
-                </div>
-              </li>
+                item={item}
+                apiBaseUrl={API_BASE_URL}
+                typeLabels={FACILITY_IMAGE_TYPE_LABELS}
+                types={FACILITY_IMAGE_TYPES}
+                canEdit={hotel.role === "owner" || hotel.role === "editor"}
+                onRequestDelete={() => setDeleteConfirmItem(item)}
+                onImageClick={() => setLightboxItem(item)}
+                onSave={(type, description) =>
+                  handleSaveImageMeta(item, type, description)
+                }
+                deleting={deletingKey === item.key}
+                saving={savingKey === item.key}
+              />
             ))}
           </ul>
+
+          {/* 削除確認モーダル */}
+          {deleteConfirmItem && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+              onClick={() => setDeleteConfirmItem(null)}
+            >
+              <div
+                className="bg-white rounded-lg shadow-xl max-w-sm w-full p-6"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <p className="text-gray-900 font-medium mb-4">
+                  この写真を削除してもよろしいですか？
+                </p>
+                <div className="flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={() => setDeleteConfirmItem(null)}
+                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(deleteConfirmItem)}
+                    disabled={deletingKey === deleteConfirmItem.key}
+                    className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 inline-flex items-center gap-2"
+                  >
+                    {deletingKey === deleteConfirmItem.key ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : null}
+                    削除する
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 画像拡大＋編集モーダル */}
+          {lightboxItem && (
+            <ImageLightboxModal
+              item={lightboxItem}
+              apiBaseUrl={API_BASE_URL}
+              typeLabels={FACILITY_IMAGE_TYPE_LABELS}
+              types={FACILITY_IMAGE_TYPES}
+              canEdit={hotel.role === "owner" || hotel.role === "editor"}
+              onClose={() => setLightboxItem(null)}
+              onSave={async (type, description) => {
+                await handleSaveImageMeta(lightboxItem, type, description);
+                setLightboxItem(null);
+              }}
+              saving={savingKey === lightboxItem.key}
+            />
+          )}
         </section>
       )}
 
-      {/* アップロード（owner/editor かつ 10枚未満のとき） */}
+      {/* 保留中の写真 + 登録するボタン（owner/editor かつ 10枚未満のとき） */}
       {(hotel.role === "owner" || hotel.role === "editor") && (
         <section className="mb-8">
           <h2 className="text-lg font-medium text-gray-900 mb-3">
@@ -269,72 +533,123 @@ export default function FacilityHotelImagesPage() {
           </h2>
           {canAddMore ? (
             <>
-              <div className="flex flex-wrap gap-4 mb-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    種別
-                  </label>
-                  <select
-                    value={uploadType}
-                    onChange={(e) => setUploadType(e.target.value)}
-                    disabled={uploading}
-                    className="block w-full min-w-[160px] px-3 py-2 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 disabled:opacity-50"
-                  >
-                    {FACILITY_IMAGE_TYPES.map((t) => (
-                      <option key={t} value={t}>
-                        {FACILITY_IMAGE_TYPE_LABELS[t]}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex-1 min-w-[200px]">
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    説明（任意）
-                  </label>
-                  <input
-                    type="text"
-                    value={uploadDescription}
-                    onChange={(e) => setUploadDescription(e.target.value)}
-                    disabled={uploading}
-                    placeholder="例：客室から見た庭園"
-                    className="block w-full px-3 py-2 border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 disabled:opacity-50"
-                  />
-                </div>
-              </div>
-
               <div
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
-                className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center bg-gray-50 hover:border-teal-400 transition-colors"
+                className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center bg-gray-50 hover:border-teal-400 transition-colors mb-4"
               >
                 <input
+                  ref={fileInputRef}
                   type="file"
-                  id="facility-image-upload"
                   accept=".jpg,.jpeg,.png,.webp"
                   multiple
                   disabled={uploading}
-                  onChange={(e) => handleFiles(e.target.files)}
+                  onChange={(e) => {
+                    addFilesToPending(e.target.files);
+                    e.target.value = "";
+                  }}
                   className="hidden"
                 />
-                <label
-                  htmlFor="facility-image-upload"
-                  className="cursor-pointer flex flex-col items-center"
+                <Upload className="h-10 w-10 text-gray-400 mx-auto mb-2" />
+                <p className="text-sm font-medium text-gray-700 mb-1">
+                  ここに写真をドラッグするか、下のボタンで選んでください
+                </p>
+                <p className="text-xs text-gray-500 mb-4">
+                  jpg, png, webp（複数選択可・あと{remainingSlots}枚まで）
+                </p>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploading}
+                  className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50"
                 >
-                  <Upload className="h-12 w-12 text-gray-400 mb-2" />
-                  <p className="text-sm font-medium text-gray-700 mb-1">
-                    ここに写真をドラッグするか、下のボタンで選んでください
-                  </p>
-                  <p className="text-xs text-gray-500 mb-4">
-                    jpg, png, webp（複数選択可・最大{MAX_IMAGES - images.length}枚まで）
-                  </p>
-                  <span className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50">
-                    ファイルを選ぶ
-                  </span>
-                </label>
+                  ファイルを選ぶ
+                </button>
               </div>
 
+              {/* 保留中の写真一覧（1枚ごとに種別・説明） */}
+              {pendingItems.length > 0 && (
+                <div className="mb-4">
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">
+                    保留中の写真（{pendingItems.length}枚）
+                  </h3>
+                  <ul className="space-y-3">
+                    {pendingItems.map((item) => (
+                      <li
+                        key={item.id}
+                        className="flex items-start gap-4 p-3 bg-gray-50 rounded-lg border border-gray-200"
+                      >
+                        <div className="relative flex-shrink-0 w-24 h-24 rounded overflow-hidden bg-gray-200">
+                          <img
+                            src={item.previewUrl}
+                            alt=""
+                            className="w-full h-full object-cover"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removePending(item.id)}
+                            disabled={uploading}
+                            className="absolute left-1 top-1 p-1 rounded bg-black/50 text-white hover:bg-red-600 disabled:opacity-50"
+                            title="削除"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                        <div className="flex-1 min-w-0 space-y-2">
+                          <div>
+                            <select
+                              value={item.type}
+                              onChange={(e) =>
+                                updatePendingItem(item.id, {
+                                  type: e.target.value,
+                                })
+                              }
+                              disabled={uploading}
+                              className="block w-full max-w-[140px] px-2 py-1.5 text-sm border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+                            >
+                              {FACILITY_IMAGE_TYPES.map((t) => (
+                                <option key={t} value={t}>
+                                  {FACILITY_IMAGE_TYPE_LABELS[t]}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <input
+                            type="text"
+                            value={item.description}
+                            onChange={(e) =>
+                              updatePendingItem(item.id, {
+                                description: e.target.value,
+                              })
+                            }
+                            disabled={uploading}
+                            placeholder="説明（任意）"
+                            className="block w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+                          />
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    type="button"
+                    onClick={handleUploadAll}
+                    disabled={uploading}
+                    className="mt-3 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50"
+                  >
+                    {uploading ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                        登録中...
+                      </>
+                    ) : (
+                      "登録する"
+                    )}
+                  </button>
+                </div>
+              )}
+
               {uploadProgress && (
-                <div className="mt-4 flex items-center gap-2 text-sm text-gray-700">
+                <div className="flex items-center gap-2 text-sm text-gray-700 mb-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
                   <span>
                     {uploadProgress.current} / {uploadProgress.total} 枚目 —{" "}
@@ -343,7 +658,7 @@ export default function FacilityHotelImagesPage() {
                 </div>
               )}
               {uploadError && (
-                <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
                   {uploadError}
                 </div>
               )}
@@ -356,5 +671,139 @@ export default function FacilityHotelImagesPage() {
         </section>
       )}
     </div>
+  );
+}
+
+type RegisteredImageCardProps = {
+  item: FacilityImageItem;
+  apiBaseUrl: string;
+  typeLabels: Record<string, string>;
+  types: string[];
+  canEdit: boolean;
+  onRequestDelete: () => void;
+  onImageClick: () => void;
+  onSave: (type: string, description: string) => void;
+  deleting: boolean;
+  saving: boolean;
+};
+
+function RegisteredImageCard({
+  item,
+  apiBaseUrl,
+  typeLabels,
+  types,
+  canEdit,
+  onRequestDelete,
+  onImageClick,
+  onSave,
+  deleting,
+  saving,
+}: RegisteredImageCardProps) {
+  // 後方互換: panorama は API で廃止のため編集時は exterior として扱う
+  const normalizedType =
+    item.type === "panorama" ? "exterior" : item.type;
+  const [editType, setEditType] = useState(normalizedType);
+  const [editDescription, setEditDescription] = useState(item.description ?? "");
+
+  useEffect(() => {
+    setEditType(item.type === "panorama" ? "exterior" : item.type);
+    setEditDescription(item.description ?? "");
+  }, [item.type, item.description]);
+
+  const hasChange =
+    editType !== item.type || editDescription !== (item.description ?? "");
+
+  return (
+    <li className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onImageClick}
+        onKeyDown={(e) => e.key === "Enter" && onImageClick()}
+        className="h-[200px] bg-gray-100 relative cursor-pointer focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-inset"
+      >
+        <img
+          src={`${apiBaseUrl}${item.url}`}
+          alt={item.description || item.type}
+          className="w-full h-full object-cover"
+        />
+        {canEdit && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRequestDelete();
+            }}
+            disabled={deleting}
+            className="absolute top-1 right-1 p-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+            title="削除"
+          >
+            {deleting ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Trash2 className="h-3 w-3" />
+            )}
+          </button>
+        )}
+      </div>
+      <div className="p-2 space-y-1.5">
+        {canEdit ? (
+          <>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-0.5">
+                種別
+              </label>
+              <select
+                value={editType}
+                onChange={(e) => setEditType(e.target.value)}
+                disabled={saving}
+                className="block w-full px-1.5 py-1 text-xs border border-gray-300 rounded-md text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+              >
+                {types.map((t) => (
+                  <option key={t} value={t}>
+                    {typeLabels[t] ?? t}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-0.5">
+                説明
+              </label>
+              <input
+                type="text"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                disabled={saving}
+                placeholder="説明（任意）"
+                className="block w-full px-1.5 py-1 text-xs border border-gray-300 rounded-md text-gray-900 focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+              />
+            </div>
+            {hasChange && (
+              <button
+                type="button"
+                onClick={() => onSave(editType, editDescription)}
+                disabled={saving}
+                className="inline-flex items-center px-2 py-1 text-xs font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50"
+              >
+                {saving ? (
+              <Loader2 className="h-3 w-3 animate-spin mr-1" />
+            ) : null}
+                保存
+              </button>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="font-medium text-gray-700 text-xs">
+              {typeLabels[item.type] ?? item.type}
+            </span>
+            {item.description && (
+              <p className="text-gray-500 text-xs line-clamp-2">{item.description}</p>
+            )}
+          </>
+        )}
+      </div>
+    </li>
   );
 }

--- a/frontend/src/app/facility/hotels/page.tsx
+++ b/frontend/src/app/facility/hotels/page.tsx
@@ -14,6 +14,7 @@ import {
   Phone,
   Globe,
   BrainCircuit,
+  ImageIcon,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -153,6 +154,17 @@ export default function FacilityHotelsPage() {
                     </div>
                   </div>
                   <div className="flex items-center space-x-2">
+                    {/* 施設画像管理へのリンク */}
+                    {(hotel.role === "owner" || hotel.role === "editor") && (
+                      <Link
+                        href={`/facility/hotels/${hotel.id}/images`}
+                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                        title="施設の写真を管理"
+                      >
+                        <ImageIcon className="h-4 w-4 mr-1" />
+                        画像を管理
+                      </Link>
+                    )}
                     {/* マーケティングAIへのリンク */}
                     <Link
                       href={`/marketing/${hotel.id}/dashboard`}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -49,6 +49,7 @@ export interface HotelResponse {
   strengths: Record<string, unknown>;
   cv_url?: string;
   hotel_assets?: HotelAssets;
+  facility_images?: FacilityImageItem[];
   role: string;
 }
 
@@ -59,6 +60,15 @@ export interface HotelAssets {
   dining?: string[];            // 料理・食事
   services?: string[];          // サービス
   experiences?: string[];       // 体験・アクティビティ
+}
+
+// 施設画像1件
+export interface FacilityImageItem {
+  key: string;
+  url: string;
+  description: string;
+  type: string;
+  order: number;
 }
 
 export interface HotelCreateRequest {
@@ -553,6 +563,81 @@ export const facilityApi = {
   async deleteHotel(hotelId: number): Promise<void> {
     await apiRequest<void>(
       `/facility/hotels/${hotelId}`,
+      {
+        method: "DELETE",
+      },
+      "facility"
+    );
+  },
+
+  /**
+   * 施設画像を1枚アップロード
+   */
+  async uploadHotelImage(
+    hotelId: number,
+    file: File,
+    type: string,
+    description?: string
+  ): Promise<FacilityImageItem> {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("type", type);
+    if (description !== undefined && description !== "") {
+      formData.append("description", description);
+    }
+
+    const makeRequest = async (token: string | null) => {
+      return fetch(
+        `${API_BASE_URL}/facility/hotels/${hotelId}/images`,
+        {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          body: formData,
+        }
+      );
+    };
+
+    let token = localStorage.getItem("facility_access_token");
+    let response = await makeRequest(token);
+
+    if (response.status === 401) {
+      const refreshToken = localStorage.getItem("facility_refresh_token");
+      if (refreshToken) {
+        try {
+          const refreshResponse = await fetch(`${API_BASE_URL}/facility/auth/refresh`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ refresh_token: refreshToken }),
+          });
+          if (refreshResponse.ok) {
+            const tokens: TokenResponse = await refreshResponse.json();
+            saveTokens("facility", tokens);
+            token = tokens.access_token;
+            response = await makeRequest(token);
+          } else {
+            clearTokens("facility");
+          }
+        } catch {
+          clearTokens("facility");
+        }
+      }
+    }
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const detail = typeof errorData.detail === "string" ? errorData.detail : "画像の登録に失敗しました";
+      throw new ApiError(response.status, detail);
+    }
+
+    return response.json();
+  },
+
+  /**
+   * 施設画像を削除
+   */
+  async deleteHotelImage(hotelId: number, imageKey: string): Promise<void> {
+    await apiRequest<void>(
+      `/facility/hotels/${hotelId}/images/${encodeURIComponent(imageKey)}`,
       {
         method: "DELETE",
       },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -646,6 +646,24 @@ export const facilityApi = {
   },
 
   /**
+   * 施設画像の種別・説明を更新
+   */
+  async updateHotelImage(
+    hotelId: number,
+    imageKey: string,
+    data: { type?: string; description?: string }
+  ): Promise<FacilityImageItem> {
+    return apiRequest<FacilityImageItem>(
+      `/facility/hotels/${hotelId}/images/${encodeURIComponent(imageKey)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+      "facility"
+    );
+  },
+
+  /**
    * 施設の資産情報を取得
    */
   async getHotelAssets(hotelId: number): Promise<HotelAssets> {


### PR DESCRIPTION
## 概要
施設管理者が施設画像を登録・編集・削除できる機能を追加

- 施設の新規登録時は、特に画像は登録しない
- 登録後の各施設管理メニュー内に「画像を管理」というボタンを設置
- 画像登録画面を作成し、その中で画像を登録できるようした

### やってないこと
広告やLPでの画像生成に登録した画像を使う処理の追加は別で対応するのでやっていない

---

## 1. フロントエンド
- **施設画像管理ページ**（`/facility/hotels/[hotelId]/images`）
  - 画像のアップロード（種別・説明付き）、削除、種別・説明の編集
  - 種別: 施設外観・内観、部屋、風呂、料理、ロビー、レストラン、周辺観光地、スタッフ、その他
  - 最大10枚、拡大表示・削除確認モーダル
- 施設一覧ページから各施設の「画像管理」リンクを追加

---

## 2. バックエンド API
- **施設画像 API**（`/api/facility/hotels/{hotel_id}/images`）
  - `POST /images` … 画像アップロード（種別・説明指定）
  - `PUT /images/{image_key}` … 種別・説明の更新
  - `DELETE /images/{image_key}` … 画像削除
- 画像の保存・削除・圧縮を `app/core/image_utils.py` に集約（Pillow 使用）
- 施設へのアクセス権（owner/viewer）に応じた権限チェック

---

## 3. データベース
- **hotels テーブル**: `facility_images` カラム（JSONB）を追加
- マイグレーション: `006_add_facility_images.py`

---

## 4. その他
- 施設画像 API・image_utils の単体テストを追加
- Persona テストの `rationale` 必須対応（テストデータ・モックの更新）

---

## テスト
- バックエンドの単体テストは`docker compose exec backend pytest tests/test_facility_images.py tests/test_image_utils.py tests/test_persona.py -v` で実施