### PR TITLE
[issue #3]施設画像参照の広告生成プロンプトを3パターン対応に改善

### DIFF
--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -233,6 +233,7 @@ async def generate_creative_assets_authenticated(
                 llm_client=llm_client_image,
                 hotel_id=hotel_id,
                 reference_images=reference_payload,
+                hotel_info={"name": hotel.name, "address": hotel.address or ""},
             )
             ad_image_gen_prompt = f"{selection_log}\n\n{generation_log}"
         
@@ -540,6 +541,7 @@ async def generate_creative_assets(
                 llm_client=llm_client_image,
                 hotel_id=hotel.id,
                 reference_images=reference_payload,
+                hotel_info={"name": hotel.name, "address": hotel.address or ""} if hotel else None,
             )
             image_gen_prompt = f"{selection_log}\n\n{generation_log}"
         

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -285,6 +285,7 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
         llm_client,
         hotel_id: int,
         reference_images: Dict[str, Dict[str, object]],
+        hotel_info: Dict = None,
     ) -> Tuple[Dict, str]:
         """
         施設画像を参照として広告画像を生成する。
@@ -295,6 +296,7 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
             hotel_id: ホテルID
             reference_images: 枠ごとの参照画像情報
                 例: {"display_wide": {"data": b"...", "mime_type": "image/webp", "url": "..."}}
+            hotel_info: 施設情報（name, address など）。パターン3のブランド署名に使用。
 
         Returns:
             (画像URL辞書, 生成ログ) のタプル
@@ -316,7 +318,7 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
                 continue
 
             try:
-                edit_prompt = await self._create_ad_edit_prompt(config["prompt"], image_type, marketing_plan, llm_client)
+                edit_prompt = await self._create_ad_edit_prompt(config["prompt"], image_type, marketing_plan, llm_client, hotel_info)
                 image_data, mime_type = await llm_client.generate_image_with_reference(
                     prompt=edit_prompt,
                     reference_image_data=ref_data,
@@ -530,28 +532,198 @@ The image should make viewers want to book immediately.""",
 
         return human_score >= facility_score
 
-    async def _create_ad_edit_prompt(self, base_prompt: str, image_type: str, plan: MarketingPlan, llm_client) -> str:
-        """参照画像編集向けの広告生成プロンプトを作成"""
-        overlay_copy = await self._derive_overlay_copy(image_type, plan, llm_client)
+    def _select_ad_pattern(self, plan: MarketingPlan) -> int:
+        """広告パターンを選択する（1: 予約促進、2: 商品理解、3: ブランド訴求）"""
+        all_text = " ".join([
+            plan.plan_name or "",
+            plan.concept or "",
+            json.dumps(plan.benefits, ensure_ascii=False),
+            json.dumps(plan.target_audience, ensure_ascii=False),
+        ])
+
+        p1_keywords = ["割引", "OFF", "off", "円引", "特典", "プレゼント", "無料", "お得", "限定価格", "特別価格"]
+        p1_score = sum(1 for kw in p1_keywords if kw in all_text)
+
+        p3_keywords = ["高級", "上質", "大人", "隠れ", "プレミアム", "ラグジュアリー", "贅沢", "至高", "一流", "こだわり"]
+        p3_score = sum(1 for kw in p3_keywords if kw in all_text)
+
+        if p1_score >= 2:
+            return 1
+        if p3_score >= 2:
+            return 3
+        return 2
+
+    def _extract_plan_text_vars(self, plan: MarketingPlan, hotel_info: Dict = None) -> Dict[str, str]:
+        """プランからパターン埋め込み用テキスト変数を抽出する"""
+        benefits = plan.benefits or {}
+        price_range = plan.price_range or {}
+
+        benefit_texts: list[str] = []
+        if isinstance(benefits, dict):
+            for v in benefits.values():
+                if isinstance(v, str) and v.strip():
+                    benefit_texts.append(v.strip())
+                elif isinstance(v, list):
+                    benefit_texts.extend(str(i).strip() for i in v if str(i).strip())
+
+        price_str = ""
+        if isinstance(price_range, dict):
+            min_p = price_range.get("min") or price_range.get("standard") or price_range.get("base")
+            if isinstance(min_p, (int, float)):
+                price_str = f"{int(min_p):,}円〜"
+            elif isinstance(min_p, str) and min_p:
+                price_str = min_p
+
+        concept_phrases = [p.strip() for p in re.split(r"[、。\n]", plan.concept or "") if p.strip()]
+        concept_short = concept_phrases[0] if concept_phrases else plan.plan_name or ""
+
+        hotel_name = ""
+        place = ""
+        if hotel_info:
+            hotel_name = hotel_info.get("name", "")
+            address = hotel_info.get("address", "")
+            if address:
+                m = re.match(r"^(.+?[都道府県])(.+?[市区町村])?", address)
+                if m:
+                    place = (m.group(1) or "") + (m.group(2) or "")
+
+        benefits_str = json.dumps(benefits, ensure_ascii=False)
+        label = "期間限定" if any(kw in benefits_str for kw in ["限定", "期間"]) else "公式サイト限定"
+
+        return {
+            "label": label,
+            "offer_big": benefit_texts[0] if benefit_texts else plan.plan_name,
+            "offer_sub": benefit_texts[1] if len(benefit_texts) > 1 else concept_short,
+            "cta_p1": "空室を確認する",
+            "footnote": "※詳細・条件は公式サイトにて確認",
+            "feature_main": benefit_texts[0] if benefit_texts else concept_short,
+            "feature_sub": benefit_texts[1] if len(benefit_texts) > 1 else (concept_phrases[1] if len(concept_phrases) > 1 else ""),
+            "support_1": benefit_texts[2] if len(benefit_texts) > 2 else "",
+            "price_or_tag": price_str or (plan.plan_name[:12] if plan.plan_name else ""),
+            "cta_p2": "詳細を見る",
+            "concept_vertical": concept_short,
+            "brand": hotel_name,
+            "place": place,
+            "mini_info": benefit_texts[0] if benefit_texts else "",
+        }
+
+    def _build_ad_prompt_pattern1(self, text_vars: Dict[str, str], aspect_ratio: str, human_instruction: str) -> str:
+        """パターン1: 数字＋CTAで予約を促進する広告プロンプト"""
+        return f"""あなたは広告バナーデザイナー。旅館の予約を促進する高品質な広告画像を生成する。
+
+# 参照画像の扱い
+提供された参照画像を背景写真として使用（撮り直し不要・施設の雰囲気を保持）。
+{human_instruction}
+背景全体をわずかに暗く（-10〜-20%）してコントラストを確保。
+
+# 出力
+- アスペクト比：{aspect_ratio}
+- 余白（セーフエリア）：四辺6%は必ず空ける
+- 文字は日本語を指定どおり正確に描画（文字化け・誤字禁止）。指定外のテキスト追加禁止。
+
+# レイアウト（予約促進型）
+- 右端に縦長のCTAボタン領域（全幅の18〜22%）を確保：角丸の濃色ボタン
+  - ボタン中央に「{text_vars["cta_p1"]}」（白字、太め、中央揃え）
+- 残り左側に「特典パネル」（全幅の60〜70%、高さ55〜70%）：半透明の金/ベージュ系、角丸
+  - パネル上部にピル型ラベル：「{text_vars["label"]}」（小さめ、中央揃え）
+  - パネル中央に最大サイズで「{text_vars["offer_big"]}」（最も大きい文字、見出し）
+  - 「{text_vars["offer_sub"]}」をその直下に（中サイズ、行間広め）
+- 画像の最下部に「{text_vars["footnote"]}」（小さめ、セーフエリア内）
+
+# トーン
+上品・高級感。文字組は整然、要素は少なく、読みやすさ最優先。"""
+
+    def _build_ad_prompt_pattern2(self, text_vars: Dict[str, str], aspect_ratio: str, human_instruction: str) -> str:
+        """パターン2: 色面ブロックで特徴を一撃表示する広告プロンプト"""
+        feature_sub_line = (
+            f"  ブロック内に「{text_vars['feature_sub']}」を縦書きまたは2行縦積み（小〜中サイズ、行間広め）"
+            if text_vars.get("feature_sub") else
+            "  ブロック内は空白（薄いアクセントカラーのみ）"
+        )
+        support_line = (
+            f"- 下部に「{text_vars['support_1']}」と「{text_vars['price_or_tag']}」を小さく横並び"
+            if text_vars.get("support_1") else
+            f"- 下部に「{text_vars['price_or_tag']}」を小さく表示"
+        )
+        return f"""あなたは広告バナーデザイナー。旅館の特徴を一瞬で理解させる広告画像を生成する。
+
+# 参照画像の扱い
+提供された参照画像を背景写真として使用（撮り直し不要・施設の雰囲気を保持）。
+{human_instruction}
+背景の主役（風呂・景色）を邪魔しない位置に文字ブロックを置くため、被写体は右側または奥側に寄せた構図に調整。
+
+# 出力
+- アスペクト比：{aspect_ratio}
+- セーフエリア：四辺6%
+- 文字は日本語を指定どおり正確に描画。指定外のテキスト追加禁止。
+
+# レイアウト（色面ブロック型）
+- 画面中央〜やや左に「メイン色面ブロック」（全幅40〜50%、高さ45〜60%）：不透明寄り（85〜95%）
+  - ブロック内に「{text_vars['feature_main']}」を最大サイズで（白字、太字、中央揃え）
+- メインブロック左に「サブ縦長ブロック」（全幅12〜18%、高さ45〜60%）：濃色（黒/濃茶）で半透明
+{feature_sub_line}
+{support_line}
+- 右下に小さなCTAボタン「{text_vars['cta_p2']}」（角丸、目立たせすぎない）
+
+# トーン
+和・温かさ・上品。写真の空気感を残しつつ、文字はブロックで確実に読ませる。"""
+
+    def _build_ad_prompt_pattern3(self, text_vars: Dict[str, str], aspect_ratio: str, human_instruction: str) -> str:
+        """パターン3: 縦書きコンセプト＋ミニマルなブランド訴求プロンプト"""
+        brand_parts = []
+        if text_vars.get("place"):
+            brand_parts.append(f"「{text_vars['place']}」を小さく")
+        if text_vars.get("brand"):
+            brand_parts.append(f"「{text_vars['brand']}」をやや大きく")
+        if text_vars.get("mini_info"):
+            brand_parts.append(f"「{text_vars['mini_info']}」をさらに小さく添える（入れすぎない）")
+        brand_block = (
+            "- 左下にブランド署名：" + "、".join(brand_parts)
+            if brand_parts else
+            "- 左下のブランド署名は省略"
+        )
+        return f"""あなたは高級旅館のアートディレクター。世界観で惹きつけるミニマルな広告画像を生成する。
+
+# 参照画像の扱い
+提供された参照画像を背景写真として使用（撮り直し不要・施設の静けさと世界観を保持）。
+{human_instruction}
+右側に暗めのグラデーション（右→左に透明へ）を薄く入れ、縦書きの可読性を確保。
+
+# 出力
+- アスペクト比：{aspect_ratio}
+- セーフエリア：四辺8%（この型は余白多め）
+- 文字は日本語を指定どおり正確に描画。指定外のテキスト追加禁止。
+
+# レイアウト（縦書きコンセプト型）
+- 右端（全幅18〜24%）に縦書きで「{text_vars['concept_vertical']}」を配置
+  - 明朝体、白字、行間ゆったり、文字サイズは"読める最小限"より少し大きめ
+{brand_block}
+- CTAや価格は入れない（世界観優先）
+
+# トーン
+上品、静けさ、余白。広告臭を抑え、指名検索・保存される見え方を狙う。"""
+
+    async def _create_ad_edit_prompt(self, base_prompt: str, image_type: str, plan: MarketingPlan, llm_client, hotel_info: Dict = None) -> str:
+        """参照画像編集向けの広告生成プロンプトを作成（3パターン切り替え）"""
+        pattern = self._select_ad_pattern(plan)
+        aspect_ratio_map = {"display_wide": "16:9", "display_square": "1:1", "display_vertical": "9:16"}
+        aspect_ratio = aspect_ratio_map.get(image_type, "1:1")
+        text_vars = self._extract_plan_text_vars(plan, hotel_info)
         add_human = self._should_add_human_presence(plan)
 
         human_instruction = (
-            "2) Add natural human presence (guest or staff) to increase warmth and trust, while avoiding uncanny faces. "
-            "STRICTLY PROHIBITED: Do NOT add any people if the scene depicts a bath, hot spring (onsen), bathtub, or any bathing area."
+            "人物（宿泊客またはスタッフ）を自然に追加して温かみと信頼感を演出する。"
+            "ただし入浴シーン・露天風呂・大浴場には絶対に人物を追加しないこと。"
             if add_human else
-            "2) Keep the scene without people — focus on the atmosphere, space, and details of the facility."
+            "人物は追加せず、施設・空間・料理のディテールにフォーカスする。"
         )
 
-        return f"""{base_prompt}
-
-Use the provided reference image as the primary visual base.
-Keep the facility identity and atmosphere recognizable.
-Add ad-positive enhancements:
-1) Embed a short Japanese promotional text naturally in the image (readable, elegant, not excessive): "{overlay_copy}".
-{human_instruction}
-3) Preserve photorealistic quality suitable for hotel advertising.
-4) Avoid logos/watermarks and avoid overcrowded composition.
-"""
+        if pattern == 1:
+            return self._build_ad_prompt_pattern1(text_vars, aspect_ratio, human_instruction)
+        elif pattern == 3:
+            return self._build_ad_prompt_pattern3(text_vars, aspect_ratio, human_instruction)
+        else:
+            return self._build_ad_prompt_pattern2(text_vars, aspect_ratio, human_instruction)
 
     def _format_generation_summary(self, configs: Dict, logs: list, category: str = "画像") -> str:
         """生成サマリーをフォーマット"""


### PR DESCRIPTION
https://github.com/kazunoriboy/marketing-planner/pull/7#issuecomment-3938552770

```
テキストの配置については、Pinterestなどで、参考になりそうなものを見つけて、いくつか画像のパターンを作り、適切なものを選択するような構成にするとよいかと思いました
```

上記コメントの対応だけ切り出して別ブランチにしています。

## 概要

施設画像を参照した広告画像生成（`generate_ad_images_with_references`）のプロンプトを、
プランの訴求軸に応じた3パターンに自動切り替えする仕組みに刷新した。

あわせて、オーバーレイコピーのプラン連動生成と人物追加の適否判定も実装している。

---

## 変更内容

### `backend/app/services/creative_generator.py`

#### パターン切り替え（新規）
- `_select_ad_pattern(plan)` — benefits/concept/target_audience のキーワードスコアでパターンを選択
  - P1スコア ≥ 2 → パターン1（予約促進）
  - P3スコア ≥ 2 → パターン3（ブランド訴求）
  - それ以外 → パターン2（商品理解）、デフォルト
- `_extract_plan_text_vars(plan, hotel_info)` — benefits/price_range/concept/hotel_info からテキスト変数を抽出
- `_build_ad_prompt_pattern1` — 数字＋CTA・予約促進型レイアウトプロンプト
- `_build_ad_prompt_pattern2` — 色面ブロック・商品理解型レイアウトプロンプト
- `_build_ad_prompt_pattern3` — 縦書きミニマル・ブランド訴求型レイアウトプロンプト（hotel_info の施設名・都道府県をブランド署名に使用）

#### オーバーレイコピー生成（新規）
- `_derive_overlay_copy(image_type, plan, llm_client)` — プランのフレーズから自然に16文字以内のコピーを導出。見つからない場合はLLMにフォールバック
- `_generate_overlay_copy_with_llm(...)` — LLMを使った16文字以内のコピー生成（max_tokens=50）

#### 人物追加の判定（新規）
- `_should_add_human_presence(plan)` — ファミリー・一人旅・体験系キーワード vs 施設・料理系キーワードのスコア比較で人物追加要否を判定

#### 更新
- `_create_ad_edit_prompt` — `hotel_info` パラメータを追加。パターン選択→テキスト変数抽出→ビルドメソッドの流れに変更（`_derive_overlay_copy` の呼び出しを廃止）
- `generate_ad_images_with_references` — `hotel_info: Dict = None` パラメータを追加

### `backend/app/api/creative.py`

- `generate_creative_assets_authenticated`（L231）: `hotel_info` を追加
- `generate_creative_assets`（L538）: `hotel_info` を追加（`hotel` が None の場合は `None` を渡す）

---

## 動作確認

| 確認項目 | 期待挙動 |
|---|---|
| 割引・特典系ワード（"特典", "無料" など）を2つ以上含むプランで生成 | パターン1（右端CTAボタン＋特典パネル）のプロンプトが使われる |
| 高級・ブランド系ワード（"贅沢", "上質" など）を2つ以上含むプランで生成 | パターン3（縦書きコンセプト＋ブランド署名）のプロンプトが使われ、施設名・都道府県が含まれる |
| 上記どちらでもないプランで生成 | パターン2（色面ブロック＋特徴テキスト）のプロンプトが使われる |
| 温泉・露天風呂の写真を参照画像に使って人物ありプランで生成 | プロンプトに「入浴シーン・露天風呂には人物を追加しないこと」が含まれる |
| hotel_info なし（`generate_creative_assets` で hotel=None のケース）で生成 | パターン3のブランド署名が省略されてエラーにならない |

---
## スクショ

<img width="2107" height="543" alt="image" src="https://github.com/user-attachments/assets/ba807c64-aade-49ce-b8c5-2f46c467e0d5" />
<img width="2099" height="535" alt="image" src="https://github.com/user-attachments/assets/fcdbd982-55ba-4745-9842-6825f3a5ed0d" />
<img width="2092" height="543" alt="image" src="https://github.com/user-attachments/assets/c05112c7-756f-49ec-b081-aa6b6401033b" />

