### PR TITLE
[issue #5] Googleマップ口コミ機能の削除

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -892,8 +892,8 @@ async def update_review_urls(
 ):
     """
     口コミURLを登録・更新
-    
-    じゃらん、Googleマップなどの口コミページURLを登録します。
+
+    じゃらんの口コミページURLを登録します。
     """
     hotel = session.get(Hotel, hotel_id)
     if not hotel:
@@ -910,14 +910,6 @@ async def update_review_urls(
                 detail="じゃらんのURLの形式が不正です"
             )
         new_urls["jalan"] = urls.jalan
-    
-    if urls.google:
-        if not review_service.validate_url(urls.google, "google"):
-            raise HTTPException(
-                status_code=400,
-                detail="GoogleマップのURLの形式が不正です"
-            )
-        new_urls["google"] = urls.google
     
     # 既存のURLとマージ
     current_urls = hotel.review_urls or {}

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -101,7 +101,6 @@ class HotelResponse(BaseModel):
 class ReviewUrlsUpdate(BaseModel):
     """口コミURL更新リクエスト"""
     jalan: Optional[str] = None
-    google: Optional[str] = None
 
 
 class ReviewUrlsResponse(BaseModel):

--- a/backend/app/services/dify_client.py
+++ b/backend/app/services/dify_client.py
@@ -112,7 +112,7 @@ class DifyClient:
         
         Args:
             review_url: 口コミページのURL
-            site_type: サイトタイプ（jalan/google）
+            site_type: サイトタイプ（jalan）
             user: ユーザー識別子
         
         Returns:

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -7,6 +7,7 @@ import json
 import re
 from typing import Optional
 from datetime import datetime
+import httpx
 
 from app.services.dify_client import get_dify_client, DifyClient
 
@@ -19,10 +20,6 @@ class ReviewService:
         "jalan": {
             "name": "じゃらん",
             "url_pattern": r"jalan\.net",
-        },
-        "google": {
-            "name": "Googleマップ",
-            "url_pattern": r"google\.(com|co\.jp)/maps",
         },
     }
     
@@ -41,8 +38,8 @@ class ReviewService:
         
         Args:
             url: 検証するURL
-            site_type: サイトタイプ（jalan/google）
-        
+            site_type: サイトタイプ（jalan）
+
         Returns:
             URLが有効かどうか
         """
@@ -126,7 +123,7 @@ class ReviewService:
         
         Args:
             review_urls: サイトタイプとURLのマッピング
-                         例: {"jalan": "https://...", "google": "https://..."}
+                         例: {"jalan": "https://..."}
         
         Returns:
             統合された分析結果:

--- a/frontend/src/app/marketing/[hotelId]/persona/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/persona/page.tsx
@@ -740,7 +740,6 @@ export default function PersonaPage() {
   // 口コミURL関連のstate
   const [reviewUrls, setReviewUrls] = useState<Record<string, string>>({});
   const [jalanUrl, setJalanUrl] = useState("");
-  const [googleUrl, setGoogleUrl] = useState("");
   const [savingUrls, setSavingUrls] = useState(false);
   const [analyzingReviews, setAnalyzingReviews] = useState(false);
   const [urlSaveMessage, setUrlSaveMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -764,7 +763,6 @@ export default function PersonaPage() {
         if (urlsData?.review_urls) {
           setReviewUrls(urlsData.review_urls);
           setJalanUrl(urlsData.review_urls.jalan || "");
-          setGoogleUrl(urlsData.review_urls.google || "");
         }
         if (personasData?.personas) {
           setPersonas(personasData.personas);
@@ -859,7 +857,6 @@ export default function PersonaPage() {
     try {
       const urls: ReviewUrlsUpdate = {};
       if (jalanUrl.trim()) urls.jalan = jalanUrl.trim();
-      if (googleUrl.trim()) urls.google = googleUrl.trim();
 
       const result = await marketingApi.updateReviewUrls(hotelId, urls);
       setReviewUrls(result.review_urls);
@@ -1086,7 +1083,7 @@ export default function PersonaPage() {
             </div>
 
             <p className="text-slate-400 text-sm mb-6">
-              じゃらんやGoogleマップの口コミページURLを登録すると、実際の口コミを収集・分析できます。
+              じゃらんの口コミページURLを登録すると、実際の口コミを収集・分析できます。
             </p>
 
             <div className="space-y-4 mb-6">
@@ -1103,18 +1100,6 @@ export default function PersonaPage() {
                 />
               </div>
 
-              <div>
-                <label className="block text-sm text-slate-300 mb-2">
-                  Googleマップ 口コミURL
-                </label>
-                <input
-                  type="url"
-                  value={googleUrl}
-                  onChange={(e) => setGoogleUrl(e.target.value)}
-                  placeholder="https://www.google.com/maps/place/..."
-                  className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500"
-                />
-              </div>
             </div>
 
             {urlSaveMessage && (
@@ -1130,7 +1115,7 @@ export default function PersonaPage() {
             <div className="flex gap-4">
               <button
                 onClick={handleSaveReviewUrls}
-                disabled={savingUrls || (!jalanUrl.trim() && !googleUrl.trim())}
+                disabled={savingUrls || !jalanUrl.trim()}
                 className="flex-1 bg-blue-600 text-white py-3 rounded-lg hover:bg-blue-700 transition-all font-semibold disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {savingUrls ? (
@@ -1181,17 +1166,6 @@ export default function PersonaPage() {
                     >
                       <ExternalLink className="w-4 h-4" />
                       じゃらん: {reviewUrls.jalan.substring(0, 50)}...
-                    </a>
-                  )}
-                  {reviewUrls.google && (
-                    <a
-                      href={reviewUrls.google}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-sm text-blue-400 hover:text-blue-300"
-                    >
-                      <ExternalLink className="w-4 h-4" />
-                      Google: {reviewUrls.google.substring(0, 50)}...
                     </a>
                   )}
                 </div>


### PR DESCRIPTION
## 概要
- Places API は最大5件しか口コミを取得できないため、データの偏りが生じる懸念がある
- GBP API は全件取得可能だが施設ごとの申請が必要で導入コストが高い
- 上記の理由から、今回はGoogleマップ口コミ機能を削除し、じゃらん（Dify経由）のみ対応とする

Closes #5

## 変更内容
- `frontend/.../persona/page.tsx`: `googleUrl` state・フォームUI・保存ロジック・登録済みURL表示・説明文を削除
- `backend/app/schemas/analysis.py`: `ReviewUrlsUpdate` から `google` フィールドを削除
- `backend/app/api/analysis.py`: Google URL のバリデーション・保存ロジックを削除
- `backend/app/services/review_service.py`: `SUPPORTED_SITES` から `google` エントリを削除
- `backend/app/services/dify_client.py`: docstring のサイトタイプ記載を修正

## テスト
- [ ] じゃらんURL の登録・口コミ分析が従来通り動作することを確認
  - ⚠️以下のエラーが出ます。
  今回の修正は関係なさそうですが、ご確認いただきたいです。
  `httpx - INFO - HTTP Request: POST https://dify.poseidon-inc.com/v1/workflows/run "HTTP/1.1 401 UNAUTHORIZED"`
- [x] 口コミ収集セクションにGoogleマップ関連のUIが表示されないことを確認

## 懸念
- テストでJALANの口コミの取得ができなかった件のご確認をお願いしたいです。

