### PR TITLE
[Issue #4]広告コピー品質向上 

### DIFF
--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -194,6 +194,7 @@ async def generate_creative_assets_authenticated(
         ad_image_gen_prompt = None
         ad_copy = {}
         ad_copy_prompt = None
+        ad_copy_warnings = []
         ota_text = {}
         ota_text_prompt = None
         
@@ -260,11 +261,12 @@ async def generate_creative_assets_authenticated(
         
         # 広告コピー生成
         if request.generate_ad_copy:
-            ad_copy, ad_copy_prompt = await generator.generate_ad_copy(
+            ad_copy, ad_copy_prompt, ad_copy_warnings = await generator.generate_ad_copy(
                 marketing_plan=marketing_plan,
-                llm_client=llm_client
+                llm_client=llm_client,
+                hotel_info={"name": hotel.name, "address": hotel.address or ""}
             )
-        
+
         # OTAテキスト生成（じゃらん、楽天トラベル向け）
         if request.generate_ota_text:
             ota_text, ota_text_prompt = await generator.generate_ota_text(
@@ -275,18 +277,19 @@ async def generate_creative_assets_authenticated(
                     "address": hotel.address,
                 }
             )
-        
+
         # 既存のアセットがあるか確認
         statement = select(CreativeAsset).where(
             CreativeAsset.marketing_plan_id == request.plan_id
         )
         existing_asset = session.exec(statement).first()
-        
+
         generation_prompts = {
             "lp_prompt": lp_prompt,
             "lp_image_generation_prompt": lp_image_gen_prompt,
             "ad_image_generation_prompt": ad_image_gen_prompt,
             "ad_copy_prompt": ad_copy_prompt,
+            "ad_copy_warnings": ad_copy_warnings,
             "ota_text_prompt": ota_text_prompt
         }
         
@@ -500,6 +503,7 @@ async def generate_creative_assets(
         image_gen_prompt = None
         ad_copy = {}
         ad_copy_prompt = None
+        ad_copy_warnings = []
         
         # LP生成
         if request.generate_lp:
@@ -547,21 +551,23 @@ async def generate_creative_assets(
         
         # 広告コピー生成
         if request.generate_ad_copy:
-            ad_copy, ad_copy_prompt = await generator.generate_ad_copy(
+            ad_copy, ad_copy_prompt, ad_copy_warnings = await generator.generate_ad_copy(
                 marketing_plan=marketing_plan,
-                llm_client=llm_client
+                llm_client=llm_client,
+                hotel_info={"name": hotel.name, "address": hotel.address or ""} if hotel else None
             )
-        
+
         # 既存のアセットがあるか確認
         statement = select(CreativeAsset).where(
             CreativeAsset.marketing_plan_id == request.marketing_plan_id
         )
         existing_asset = session.exec(statement).first()
-        
+
         generation_prompts = {
             "lp_prompt": lp_prompt,
             "image_generation_prompt": image_gen_prompt,
-            "ad_copy_prompt": ad_copy_prompt
+            "ad_copy_prompt": ad_copy_prompt,
+            "ad_copy_warnings": ad_copy_warnings
         }
         
         if existing_asset:

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -738,42 +738,59 @@ The image should make viewers want to book immediately.""",
     async def generate_ad_copy(
         self,
         marketing_plan: MarketingPlan,
-        llm_client
-    ) -> Tuple[Dict, str]:
+        llm_client,
+        hotel_info: Dict = None
+    ) -> Tuple[Dict, str, list]:
         """
         広告コピーを生成
-        
+
         Args:
             marketing_plan: マーケティングプラン
             llm_client: LLMクライアント
-        
+            hotel_info: 施設情報（name, address）
+
         Returns:
-            (広告コピー辞書, 生成プロンプト) のタプル
+            (広告コピー辞書, 生成プロンプト, warnings) のタプル
         """
         # ターゲット言語を取得
         target_language = self._get_target_language(marketing_plan)
         language_instruction = get_language_instruction(target_language)
         language_name = get_language_name(target_language)
-        
-        prompt = self._create_ad_copy_generation_prompt(marketing_plan, target_language)
-        
-        system_prompt = f"""あなたは宿泊業界の経験豊富なコピーライターです。
-魅力的で効果的な広告コピーを作成してください。
+
+        prompt = self._create_ad_copy_generation_prompt(marketing_plan, target_language, hotel_info=hotel_info)
+
+        system_prompt = f"""あなたは広告コピーライターの専門家です。
+ホテル・旅館の予約促進広告において、クリック率と予約転換率を最大化するコピーを作成してください。
+
+【Google 検索広告（RSA）のコピー原則】
+- どの見出し3本の組み合わせでも意味が完結するよう、各見出しは独立して成立させる
+- ブランド訴求・ベネフィット訴求・限定性訴求など、異なる角度から書く
+- 検索意図（旅行先探し・宿泊予約）に直結したキーワードを自然に含める
+
+【Meta 広告（Facebook / Instagram）のコピー原則】
+- Primary Text の冒頭1〜2行がフィードの「続きを見る」折りたたみ前に表示される唯一のチャンス
+- フック（冒頭）→ 価値提示 → CTA の構造を守る
+- 3案は「感情訴求」「お得・特典訴求」「問題解決訴求」で明確に角度を変える
 
 【重要：出力言語】
 {language_instruction}
 すべての広告コピーを{language_name}で作成してください。"""
-        
+
         response = await llm_client.generate_structured_output(
             user_prompt=prompt,
             system_prompt=system_prompt,
-            max_tokens=2000
+            max_tokens=3000
         )
-        
+
         # コピーを抽出
         ad_copy = self._parse_ad_copy(response)
-        
-        return ad_copy, prompt
+
+        # 文字数バリデーション
+        warnings = self._validate_ad_copy_lengths(ad_copy)
+        if warnings:
+            print(f"広告コピー文字数警告: {warnings}")
+
+        return ad_copy, prompt, warnings
     
     def _create_lp_generation_prompt(
         self, 
@@ -948,45 +965,130 @@ The image should make viewers want to book immediately.""",
 }}
 """
     
-    def _create_ad_copy_generation_prompt(self, plan: MarketingPlan, target_language: str = "ja") -> str:
+    def _create_ad_copy_generation_prompt(self, plan: MarketingPlan, target_language: str = "ja", hotel_info: Dict = None) -> str:
         """広告コピー生成プロンプトを作成"""
         language_instruction = get_language_instruction(target_language)
         language_name = get_language_name(target_language)
-        
+
+        # 施設情報セクション
+        hotel_section = ""
+        if hotel_info:
+            hotel_section = f"""
+【施設情報】
+施設名: {hotel_info.get('name', '')}
+所在地: {hotel_info.get('address', '')}
+"""
+
+        # 価格帯
+        price_section = ""
+        if getattr(plan, 'price_range', None):
+            price_section = f"価格帯: {plan.price_range}\n"
+
+        # 競合差別化（3C分析）
+        strategy_section = ""
+        strategy_3c = getattr(plan, 'strategy_3c', None)
+        if strategy_3c and isinstance(strategy_3c, dict):
+            customer_value = strategy_3c.get('customer_value', '')
+            competitor_diff = strategy_3c.get('competitor_diff', '')
+            if customer_value or competitor_diff:
+                strategy_section = f"""
+【競合差別化ポイント（3C分析）】
+顧客価値: {customer_value}
+競合との差別化: {competitor_diff}
+"""
+
         return f"""
-以下のマーケティングプランに基づいて、複数の広告コピーを作成してください。
-
-【重要：出力言語】
-{language_instruction}
-すべての広告コピーを{language_name}で作成してください。
-
+以下のマーケティングプランに基づいて、各プラットフォーム向け広告コピーを作成してください。
+{hotel_section}
 【プラン情報】
 プラン名: {plan.plan_name}
 コンセプト: {plan.concept}
 ターゲット層: {json.dumps(plan.target_audience, ensure_ascii=False)}
 特典: {json.dumps(plan.benefits, ensure_ascii=False)}
+{price_section}{strategy_section}
+広告コピーの文字数制限は厳密に守ってください。
+【Google広告 - レスポンシブ検索広告（RSA）】
+- headlines: 5本生成。1件あたり15文字以内厳守
+  - 見出し#1: 施設のUSP・際立った特徴（例:「源泉かけ流し 露天風呂付き客室」）
+  - 見出し#2: ターゲットが得るベネフィット・体験価値（例:「日常を忘れる癒しの2日間」）
+  - 見出し#3: 限定性・希少性（例:「週末限定 特別会席プラン」）
+  - 見出し#4: 社会的証明・信頼性（例:「口コミ評価4.8 選ばれる宿」）
+  - 見出し#5: CTA・行動促進（例:「今すぐ予約で特典付き」）
+  - どの3本の組み合わせでも意味が完結するよう、各見出しは独立して成立させること
+- descriptions: 3本生成。1件あたり45文字以内厳守
+- path1: サービスカテゴリを表す短い語。15文字以内。
+- path2: 地域名またはプラン名。15文字以内。
 
-以下のJSON形式で出力してください（すべて{language_name}で記述）：
+【Meta広告（Facebook）】
+- primary_texts: 125文字以内厳守、3案生成、冒頭1〜2行をフック（読者の注意を引く文）→ 価値提示 → CTAの構造で書く。
+  - 案1: 感情・ストーリー訴求（例:「〇〇に疲れていませんか？」で始める）
+  - 案2: お得・特典訴求（例:「【期間限定】〇〇が無料でついてくるプラン」で始める）
+  - 案3: 問題解決・ニーズ直撃（例:「〇〇をお探しなら、このプランがぴったりです」で始める）
+- headlines: 3案生成。各40文字以内を目安（超過で省略されやすい）。
+- descriptions: 3案生成。各20〜30文字程度を目安（表示されない配置も多い）。
+- cta: "詳しくはこちら" / "今すぐ予約" / "お問い合わせ" から最適なものを1つ。
+
+【Meta広告（Instagram）】
+- primary_texts:  125文字以内厳守、3案生成、冒頭1〜2行をフック（読者の注意を引く文）→ 価値提示 → CTAの構造で書く
+  （Facebookと同様の3角度で、Instagramユーザー向けに調整）
+- headlines: 3案生成。各40文字以内を目安。
+- descriptions: 3案生成。各20〜30文字程度を目安。
+- hashtags: ホテル名・地域・体験カテゴリを含む10〜15個程度。
+
+以下のJSON形式のみで出力してください（すべて{language_name}で記述。コードブロック不要）：
 {{
-    "headline": {{
-        "main": "メインキャッチコピー",
-        "sub": "サブコピー"
-    }},
     "google_ads": {{
-        "title_1": "Google広告タイトル1",
-        "title_2": "Google広告タイトル2",
-        "description": "説明文"
+        "headlines": [
+            "見出し1（USP・特徴）",
+            "見出し2（ベネフィット）",
+            "見出し3（限定性）",
+            "見出し4（社会的証明）",
+            "見出し5（CTA）"
+        ],
+        "descriptions": [
+            "説明文1（全角45文字以内）",
+            "説明文2",
+            "説明文3"
+        ],
+        "path1": "パス1（15文字以内）",
+        "path2": "パス2（15文字以内）"
     }},
     "facebook_ads": {{
-        "primary_text": "Facebook広告メインテキスト",
-        "headline": "見出し",
-        "description": "説明文"
+        "primary_texts": [
+            "案1（感情訴求・フック→価値提示→CTA）",
+            "案2（お得・特典訴求）",
+            "案3（問題解決訴求）"
+        ],
+        "headlines": [
+            "見出し案1",
+            "見出し案2",
+            "見出し案3"
+        ],
+        "descriptions": [
+            "説明文案1",
+            "説明文案2",
+            "説明文案3"
+        ],
+        "cta": "詳しくはこちら"
     }},
-    "instagram_caption": {{
-        "main_text": "Instagram投稿テキスト",
-        "hashtags": ["#ハッシュタグ1", "#ハッシュタグ2", "#ハッシュタグ3"]
-    }},
-    "email_subject": "メール件名"
+    "instagram_ads": {{
+        "primary_texts": [
+            "案1（感情訴求）",
+            "案2（お得・特典訴求）",
+            "案3（問題解決訴求）"
+        ],
+        "headlines": [
+            "見出し案1",
+            "見出し案2",
+            "見出し案3"
+        ],
+        "descriptions": [
+            "説明文案1",
+            "説明文案2",
+            "説明文案3"
+        ],
+        "hashtags": ["#ハッシュタグ1", "#ハッシュタグ2"]
+    }}
 }}
 """
     
@@ -1053,26 +1155,78 @@ The image should make viewers want to book immediately.""",
         except Exception as e:
             print(f"広告コピー解析エラー: {e}")
             return {
-                "headline": {
-                    "main": "特別なひとときを、あなたに",
-                    "sub": "心に残る宿泊体験をお届けします"
-                },
                 "google_ads": {
-                    "title_1": "今だけ特別プラン",
-                    "title_2": "快適な宿泊をお約束",
-                    "description": "ゆったりとした客室で、くつろぎのひとときを。特別な特典もご用意しております。"
+                    "headlines": [
+                        "特別な宿泊体験をあなたに",
+                        "日常を忘れる癒しの時間",
+                        "週末限定 特別プラン",
+                        "口コミ高評価の人気施設",
+                        "今すぐ予約で特典付き"
+                    ],
+                    "descriptions": [
+                        "ゆったりとした客室で、くつろぎのひとときを。特別な特典もご用意しております。",
+                        "心に残る宿泊体験をお届けします。ご予約はお早めに。",
+                        "上質なサービスと快適な環境で、忘れられない旅をお楽しみください。"
+                    ],
+                    "path1": "宿泊予約",
+                    "path2": "特別プラン"
                 },
                 "facebook_ads": {
-                    "primary_text": "日常を忘れて、特別な時間を過ごしませんか？",
-                    "headline": "今だけの特別プラン",
-                    "description": "詳しくはこちら"
+                    "primary_texts": [
+                        "日常の喧騒から離れて、本当の意味でリフレッシュしたいと思いませんか？\n\n当施設では、心と体を癒す特別な時間をご用意しています。\n\n今すぐご予約を。",
+                        "【期間限定】特別プランが登場！\n\n通常より特典充実のこのプランは、数量限定です。\n\nお早めにご予約ください。",
+                        "特別な宿泊先をお探しなら、このプランがぴったりです。\n\n上質なサービスと快適な環境で、忘れられない旅をお届けします。"
+                    ],
+                    "headlines": [
+                        "特別なひとときを、あなたに",
+                        "期間限定 特別プラン公開中",
+                        "理想の宿泊体験がここに"
+                    ],
+                    "descriptions": [
+                        "心に残る宿泊体験をお届けします",
+                        "今だけの特別特典付きプラン",
+                        "上質なサービスで癒しの時間を"
+                    ],
+                    "cta": "詳しくはこちら"
                 },
-                "instagram_caption": {
-                    "main_text": "心に残る宿泊体験を。特別なひとときをお過ごしください。",
-                    "hashtags": ["#宿泊", "#旅行", "#癒し"]
-                },
-                "email_subject": "【特別プラン】ご予約受付中"
+                "instagram_ads": {
+                    "primary_texts": [
+                        "旅の疲れを癒す、特別な時間。\n\nここでしか体験できない宿泊プランをご用意しました。\n\n#旅行 #宿泊",
+                        "【お得情報】期間限定プラン公開中！\n\n特典盛りだくさんのこのプランをお見逃しなく。\n\n詳細はリンクから。",
+                        "理想の宿泊体験をお探しですか？\n\n上質な空間と温かいおもてなしで、特別な旅をご提供します。"
+                    ],
+                    "headlines": [
+                        "特別な宿泊体験",
+                        "期間限定プラン",
+                        "理想の旅がここに"
+                    ],
+                    "descriptions": [
+                        "心に残る旅をご提供",
+                        "特典付き限定プラン",
+                        "上質な空間でリフレッシュ"
+                    ],
+                    "hashtags": ["#宿泊", "#旅行", "#癒し", "#ホテル", "#旅館", "#温泉", "#観光", "#週末旅行", "#国内旅行", "#おすすめ宿"]
+                }
             }
+
+    def _validate_ad_copy_lengths(self, ad_copy: Dict) -> list:
+        """
+        生成された広告コピーの文字数を検証し、超過フィールドを返す
+        Google: 全角1文字 = 半角2文字でカウント
+        """
+        warnings = []
+
+        def hw_len(s: str) -> int:
+            return sum(2 if ord(c) > 0x7F else 1 for c in s)
+
+        for i, h in enumerate(ad_copy.get("google_ads", {}).get("headlines", [])):
+            if hw_len(h) > 30:
+                warnings.append(f"google_ads.headlines[{i}]: {hw_len(h)}文字（上限30）")
+        for i, d in enumerate(ad_copy.get("google_ads", {}).get("descriptions", [])):
+            if hw_len(d) > 90:
+                warnings.append(f"google_ads.descriptions[{i}]: {hw_len(d)}文字（上限90）")
+
+        return warnings
     
     async def generate_ota_text(
         self,

--- a/backend/migrations/versions/006_add_facility_images.py
+++ b/backend/migrations/versions/006_add_facility_images.py
@@ -20,13 +20,29 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """hotelsテーブルにfacility_imagesカラムを追加"""
-    op.add_column(
-        'hotels',
-        sa.Column('facility_images', postgresql.JSONB(), nullable=True, server_default='[]')
-    )
+    """hotelsテーブルにfacility_imagesカラムを追加（既存の場合はスキップ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'hotels' AND column_name = 'facility_images'"
+        )
+    ).scalar()
+    if result is None:
+        op.add_column(
+            'hotels',
+            sa.Column('facility_images', postgresql.JSONB(), nullable=True, server_default='[]')
+        )
 
 
 def downgrade() -> None:
-    """facility_imagesカラムを削除"""
-    op.drop_column('hotels', 'facility_images')
+    """facility_imagesカラムを削除（存在する場合のみ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'hotels' AND column_name = 'facility_images'"
+        )
+    ).scalar()
+    if result is not None:
+        op.drop_column('hotels', 'facility_images')

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -653,37 +653,288 @@ export default function ContentPage() {
               )}
 
               {/* 広告コピー */}
-              {currentAsset.ad_copy && Object.keys(currentAsset.ad_copy).length > 0 && (
-                <div className="glass-card p-6 lg:col-span-2">
-                  <div className="flex items-center gap-3 mb-4">
-                    <MessageSquare className="w-6 h-6 text-green-400" />
-                    <h4 className="text-xl font-bold text-white">広告コピー</h4>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {Object.entries(currentAsset.ad_copy).map(([key, value]) => (
-                      <div key={key} className="p-4 bg-white/5 rounded-lg">
-                        <p className="text-sm text-slate-400 mb-2 font-medium">{key}</p>
-                        {typeof value === "object" && value !== null ? (
-                          <div className="space-y-2">
-                            {Object.entries(value as Record<string, unknown>).map(([subKey, subValue]) => (
-                              <div key={subKey}>
-                                <span className="text-xs text-slate-500">{subKey}: </span>
-                                {Array.isArray(subValue) ? (
-                                  <span className="text-slate-300">{subValue.join(" ")}</span>
-                                ) : (
-                                  <span className="text-slate-300">{String(subValue)}</span>
+              {currentAsset.ad_copy && (currentAsset.ad_copy.google_ads || currentAsset.ad_copy.facebook_ads || currentAsset.ad_copy.instagram_ads) && (() => {
+                /** 全角換算の文字数（半角=0.5、全角=1） */
+                const fullWidthLen = (s: string) =>
+                  [...s].reduce((acc, c) => acc + (c.charCodeAt(0) > 0x7F ? 1 : 0.5), 0);
+
+                const copyText = (text: string) => {
+                  navigator.clipboard.writeText(text);
+                  alert("コピーしました");
+                };
+
+                const LenBadge = ({ count, limit }: { count: number; limit: number }) => (
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-mono flex-shrink-0 ${
+                    count > limit ? "bg-red-500/20 text-red-400" : "bg-white/10 text-slate-500"
+                  }`}>
+                    {count}/{limit}
+                  </span>
+                );
+
+                const { google_ads, facebook_ads, instagram_ads } = currentAsset.ad_copy;
+
+                return (
+                  <div className="glass-card p-6 lg:col-span-2">
+                    <div className="flex items-center gap-3 mb-6">
+                      <MessageSquare className="w-6 h-6 text-green-400" />
+                      <h4 className="text-xl font-bold text-white">広告コピー</h4>
+                    </div>
+                    <div className="space-y-6">
+
+                      {/* Google 検索広告（RSA） */}
+                      {google_ads && (
+                        <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 border border-blue-700/30 rounded-xl p-6">
+                          <div className="flex items-center justify-between mb-4">
+                            <h5 className="text-base font-semibold text-blue-300">Google 検索広告（RSA）</h5>
+                            <button
+                              onClick={() => {
+                                const all = [
+                                  ...(google_ads.headlines || []),
+                                  ...(google_ads.descriptions || [])
+                                ].join("\t");
+                                copyText(all);
+                              }}
+                              className="text-xs px-3 py-1 rounded bg-blue-700/30 text-blue-300 hover:bg-blue-700/50 transition-colors"
+                            >
+                              全コピー
+                            </button>
+                          </div>
+                          {/* 見出し */}
+                          {google_ads.headlines && google_ads.headlines.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">見出し（上限: 全角15文字）</p>
+                              <div className="space-y-2">
+                                {google_ads.headlines.map((h, i) => (
+                                  <div key={i} className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 w-4 flex-shrink-0">#{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{h}</span>
+                                    <LenBadge count={fullWidthLen(h)} limit={15} />
+                                    <button onClick={() => copyText(h)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* 説明文 */}
+                          {google_ads.descriptions && google_ads.descriptions.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">説明文（上限: 全角45文字）</p>
+                              <div className="space-y-2">
+                                {google_ads.descriptions.map((d, i) => (
+                                  <div key={i} className="flex items-start gap-2">
+                                    <span className="text-xs text-slate-500 w-4 flex-shrink-0 mt-0.5">#{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{d}</span>
+                                    <LenBadge count={fullWidthLen(d)} limit={45} />
+                                    <button onClick={() => copyText(d)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Path */}
+                          {(google_ads.path1 || google_ads.path2) && (
+                            <div>
+                              <p className="text-xs text-slate-400 mb-2">表示パス（各上限15文字）</p>
+                              <div className="space-y-1">
+                                {google_ads.path1 && (
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 w-10 flex-shrink-0">path1</span>
+                                    <span className="text-slate-200 text-sm flex-1">{google_ads.path1}</span>
+                                    <LenBadge count={fullWidthLen(google_ads.path1)} limit={15} />
+                                    <button onClick={() => copyText(google_ads.path1!)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                )}
+                                {google_ads.path2 && (
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 w-10 flex-shrink-0">path2</span>
+                                    <span className="text-slate-200 text-sm flex-1">{google_ads.path2}</span>
+                                    <LenBadge count={fullWidthLen(google_ads.path2)} limit={15} />
+                                    <button onClick={() => copyText(google_ads.path2!)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
                                 )}
                               </div>
-                            ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Facebook 広告 */}
+                      {facebook_ads && (
+                        <div className="bg-gradient-to-br from-indigo-900/30 to-indigo-800/10 border border-indigo-700/30 rounded-xl p-6">
+                          <div className="flex items-center justify-between mb-4">
+                            <h5 className="text-base font-semibold text-indigo-300">Facebook 広告</h5>
+                            <button
+                              onClick={() => {
+                                const sections = (facebook_ads.primary_texts || []).map((pt, i) =>
+                                  `【案${i + 1}】\nPrimary Text: ${pt}\nHeadline: ${(facebook_ads.headlines || [])[i] || ""}\nDescription: ${(facebook_ads.descriptions || [])[i] || ""}`
+                                );
+                                copyText(sections.join("\n\n"));
+                              }}
+                              className="text-xs px-3 py-1 rounded bg-indigo-700/30 text-indigo-300 hover:bg-indigo-700/50 transition-colors"
+                            >
+                              全コピー
+                            </button>
                           </div>
-                        ) : (
-                          <p className="text-slate-300">{String(value)}</p>
-                        )}
-                      </div>
-                    ))}
+                          {/* Primary Texts */}
+                          {facebook_ads.primary_texts && facebook_ads.primary_texts.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Primary Text（冒頭125文字に重要訴求を集約）</p>
+                              <div className="space-y-3">
+                                {facebook_ads.primary_texts.map((pt, i) => (
+                                  <div key={i} className="bg-white/5 rounded-lg p-3">
+                                    <div className="flex items-center justify-between mb-1">
+                                      <span className="text-xs text-slate-400">案{i + 1}</span>
+                                      <div className="flex items-center gap-2">
+                                        <LenBadge count={pt.length} limit={125} />
+                                        <button onClick={() => copyText(pt)} className="text-slate-500 hover:text-slate-300 text-sm">📋</button>
+                                      </div>
+                                    </div>
+                                    <p className="text-slate-200 text-sm whitespace-pre-wrap">{pt}</p>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Headlines */}
+                          {facebook_ads.headlines && facebook_ads.headlines.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Headline（目安: 40文字以内）</p>
+                              <div className="space-y-2">
+                                {facebook_ads.headlines.map((h, i) => (
+                                  <div key={i} className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 flex-shrink-0">案{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{h}</span>
+                                    <LenBadge count={h.length} limit={40} />
+                                    <button onClick={() => copyText(h)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Descriptions */}
+                          {facebook_ads.descriptions && facebook_ads.descriptions.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Description（目安: 20〜30文字）</p>
+                              <div className="space-y-2">
+                                {facebook_ads.descriptions.map((d, i) => (
+                                  <div key={i} className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 flex-shrink-0">案{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{d}</span>
+                                    <LenBadge count={d.length} limit={30} />
+                                    <button onClick={() => copyText(d)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* CTA */}
+                          {facebook_ads.cta && (
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-slate-400">CTA:</span>
+                              <span className="text-slate-200 text-sm flex-1">{facebook_ads.cta}</span>
+                              <button onClick={() => copyText(facebook_ads.cta)} className="text-slate-500 hover:text-slate-300 text-sm">📋</button>
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Instagram 広告 */}
+                      {instagram_ads && (
+                        <div className="bg-gradient-to-br from-pink-900/30 to-rose-800/10 border border-pink-700/30 rounded-xl p-6">
+                          <div className="flex items-center justify-between mb-4">
+                            <h5 className="text-base font-semibold text-pink-300">Instagram 広告</h5>
+                            <button
+                              onClick={() => {
+                                const sections = (instagram_ads.primary_texts || []).map((pt, i) =>
+                                  `【案${i + 1}】\nPrimary Text: ${pt}\nHeadline: ${(instagram_ads.headlines || [])[i] || ""}\nDescription: ${(instagram_ads.descriptions || [])[i] || ""}`
+                                );
+                                const tags = (instagram_ads.hashtags || []).join(" ");
+                                copyText([...sections, `Hashtags: ${tags}`].join("\n\n"));
+                              }}
+                              className="text-xs px-3 py-1 rounded bg-pink-700/30 text-pink-300 hover:bg-pink-700/50 transition-colors"
+                            >
+                              全コピー
+                            </button>
+                          </div>
+                          {/* Primary Texts */}
+                          {instagram_ads.primary_texts && instagram_ads.primary_texts.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Primary Text（冒頭125文字に重要訴求を集約）</p>
+                              <div className="space-y-3">
+                                {instagram_ads.primary_texts.map((pt, i) => (
+                                  <div key={i} className="bg-white/5 rounded-lg p-3">
+                                    <div className="flex items-center justify-between mb-1">
+                                      <span className="text-xs text-slate-400">案{i + 1}</span>
+                                      <div className="flex items-center gap-2">
+                                        <LenBadge count={pt.length} limit={125} />
+                                        <button onClick={() => copyText(pt)} className="text-slate-500 hover:text-slate-300 text-sm">📋</button>
+                                      </div>
+                                    </div>
+                                    <p className="text-slate-200 text-sm whitespace-pre-wrap">{pt}</p>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Headlines */}
+                          {instagram_ads.headlines && instagram_ads.headlines.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Headline（目安: 40文字以内）</p>
+                              <div className="space-y-2">
+                                {instagram_ads.headlines.map((h, i) => (
+                                  <div key={i} className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 flex-shrink-0">案{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{h}</span>
+                                    <LenBadge count={h.length} limit={40} />
+                                    <button onClick={() => copyText(h)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Descriptions */}
+                          {instagram_ads.descriptions && instagram_ads.descriptions.length > 0 && (
+                            <div className="mb-4">
+                              <p className="text-xs text-slate-400 mb-2">Description（目安: 20〜30文字）</p>
+                              <div className="space-y-2">
+                                {instagram_ads.descriptions.map((d, i) => (
+                                  <div key={i} className="flex items-center gap-2">
+                                    <span className="text-xs text-slate-500 flex-shrink-0">案{i + 1}</span>
+                                    <span className="text-slate-200 text-sm flex-1">{d}</span>
+                                    <LenBadge count={d.length} limit={30} />
+                                    <button onClick={() => copyText(d)} className="text-slate-500 hover:text-slate-300 flex-shrink-0 text-sm">📋</button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {/* Hashtags */}
+                          {instagram_ads.hashtags && instagram_ads.hashtags.length > 0 && (
+                            <div>
+                              <div className="flex items-center justify-between mb-2">
+                                <p className="text-xs text-slate-400">ハッシュタグ</p>
+                                <button onClick={() => copyText(instagram_ads.hashtags.join(" "))} className="text-xs text-slate-500 hover:text-slate-300">📋 全コピー</button>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                {instagram_ads.hashtags.map((tag, i) => (
+                                  <button
+                                    key={i}
+                                    onClick={() => copyText(tag)}
+                                    className="text-xs px-2 py-1 rounded-full bg-pink-900/30 text-pink-300 hover:bg-pink-900/50 transition-colors"
+                                  >
+                                    {tag}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                    </div>
                   </div>
-                </div>
-              )}
+                );
+              })()}
 
               {/* 広告用画像 */}
               {currentAsset.ad_image_urls && Object.keys(currentAsset.ad_image_urls).length > 0 && (

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -52,6 +52,15 @@ export default function ContentPage() {
   const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
   const [modalImageTitle, setModalImageTitle] = useState<string>("");
   
+  // トースト通知のstate
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showToast = (message: string) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setToast(message);
+    toastTimerRef.current = setTimeout(() => setToast(null), 2000);
+  };
+
   // SNS投稿ジェネレーター関連のstate
   const [snsPlatform, setSnsPlatform] = useState<string>("");
   const [snsPostType, setSnsPostType] = useState<string>("");
@@ -660,7 +669,7 @@ export default function ContentPage() {
 
                 const copyText = (text: string) => {
                   navigator.clipboard.writeText(text);
-                  alert("コピーしました");
+                  showToast("コピーしました");
                 };
 
                 const LenBadge = ({ count, limit }: { count: number; limit: number }) => (
@@ -679,11 +688,11 @@ export default function ContentPage() {
                       <MessageSquare className="w-6 h-6 text-green-400" />
                       <h4 className="text-xl font-bold text-white">広告コピー</h4>
                     </div>
-                    <div className="space-y-6">
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
 
                       {/* Google 検索広告（RSA） */}
                       {google_ads && (
-                        <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 border border-blue-700/30 rounded-xl p-6">
+                        <div className="bg-gradient-to-br from-blue-900/30 to-blue-800/10 border border-blue-700/30 rounded-xl p-5">
                           <div className="flex items-center justify-between mb-4">
                             <h5 className="text-base font-semibold text-blue-300">Google 検索広告（RSA）</h5>
                             <button
@@ -760,7 +769,7 @@ export default function ContentPage() {
 
                       {/* Facebook 広告 */}
                       {facebook_ads && (
-                        <div className="bg-gradient-to-br from-indigo-900/30 to-indigo-800/10 border border-indigo-700/30 rounded-xl p-6">
+                        <div className="bg-gradient-to-br from-indigo-900/30 to-indigo-800/10 border border-indigo-700/30 rounded-xl p-5">
                           <div className="flex items-center justify-between mb-4">
                             <h5 className="text-base font-semibold text-indigo-300">Facebook 広告</h5>
                             <button
@@ -840,9 +849,9 @@ export default function ContentPage() {
 
                       {/* Instagram 広告 */}
                       {instagram_ads && (
-                        <div className="bg-gradient-to-br from-pink-900/30 to-rose-800/10 border border-pink-700/30 rounded-xl p-6">
+                        <div className="bg-gradient-to-br from-purple-900/20 to-violet-900/10 border border-purple-700/25 rounded-xl p-5">
                           <div className="flex items-center justify-between mb-4">
-                            <h5 className="text-base font-semibold text-pink-300">Instagram 広告</h5>
+                            <h5 className="text-base font-semibold text-purple-300">Instagram 広告</h5>
                             <button
                               onClick={() => {
                                 const sections = (instagram_ads.primary_texts || []).map((pt, i) =>
@@ -851,7 +860,7 @@ export default function ContentPage() {
                                 const tags = (instagram_ads.hashtags || []).join(" ");
                                 copyText([...sections, `Hashtags: ${tags}`].join("\n\n"));
                               }}
-                              className="text-xs px-3 py-1 rounded bg-pink-700/30 text-pink-300 hover:bg-pink-700/50 transition-colors"
+                              className="text-xs px-3 py-1 rounded bg-purple-700/25 text-purple-300 hover:bg-purple-700/40 transition-colors"
                             >
                               全コピー
                             </button>
@@ -920,7 +929,7 @@ export default function ContentPage() {
                                   <button
                                     key={i}
                                     onClick={() => copyText(tag)}
-                                    className="text-xs px-2 py-1 rounded-full bg-pink-900/30 text-pink-300 hover:bg-pink-900/50 transition-colors"
+                                    className="text-xs px-2 py-1 rounded-full bg-purple-900/20 text-purple-300 hover:bg-purple-900/35 transition-colors"
                                   >
                                     {tag}
                                   </button>
@@ -1605,6 +1614,16 @@ export default function ContentPage() {
                 </button>
               </div>
             </div>
+          </div>
+        </div>,
+        document.body
+      )}
+      {/* コピー完了トースト */}
+      {toast && createPortal(
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] pointer-events-none">
+          <div className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-slate-800 border border-slate-600 shadow-xl text-sm text-white animate-fadeIn">
+            <CheckCircle className="w-4 h-4 text-green-400 flex-shrink-0" />
+            {toast}
           </div>
         </div>,
         document.body

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -825,11 +825,39 @@ export interface CreativeAsset {
   lp_preview_url: string | null;
   lp_image_urls: Record<string, unknown>;
   ad_image_urls: Record<string, unknown>;
-  ad_copy: Record<string, unknown>;
+  ad_copy: AdCopyContent;
   ota_text: OTATextContent;
   generation_prompts: Record<string, unknown>;
   created_at: string;
   updated_at: string;
+}
+
+// 広告コピーの型定義
+export interface GoogleAdsContent {
+  headlines: string[];
+  descriptions: string[];
+  path1?: string;
+  path2?: string;
+}
+
+export interface FacebookAdsContent {
+  primary_texts: string[];
+  headlines: string[];
+  descriptions: string[];
+  cta: string;
+}
+
+export interface InstagramAdsContent {
+  primary_texts: string[];
+  headlines: string[];
+  descriptions: string[];
+  hashtags: string[];
+}
+
+export interface AdCopyContent {
+  google_ads: GoogleAdsContent;
+  facebook_ads: FacebookAdsContent;
+  instagram_ads: InstagramAdsContent;
 }
 
 // OTAテキストの型定義


### PR DESCRIPTION
## 概要

- Google 検索広告（RSA）・Facebook 広告・Instagram 広告の3プラットフォームに対応した新しい JSON 構造（`google_ads` / `facebook_ads` / `instagram_ads`）にフィールドを整備
- LLM プロンプトを刷新（訴求軸フレームワーク・RSA独立性・Meta フック構造・施設情報/競合差別化コンテキストを注入）
- 生成後に Python 側で文字数バリデーションを実施し、超過フィールドを `ad_copy_warnings` に記録
- フロントエンドの広告コピー UI をプラットフォームごとのカード（3列）に刷新（文字数バッジ・個別/全コピーボタン・トースト通知）

## 変更点

### Backend
- `creative_generator.py`: `generate_ad_copy()` に `hotel_info` 引数と warnings 返り値を追加、system_prompt 強化、`_create_ad_copy_generation_prompt()` を新フォーマット・訴求軸フレームワーク付きで刷新、`_parse_ad_copy()` フォールバックを新構造に更新、`_validate_ad_copy_lengths()` を新規追加
- `api/creative.py`: 2箇所の `generate_ad_copy()` 呼び出しを `hotel_info` 渡し・3タプルアンパック・`ad_copy_warnings` 保存に更新

### Frontend
- `api.ts`: `GoogleAdsContent` / `FacebookAdsContent` / `InstagramAdsContent` / `AdCopyContent` 型を追加、`CreativeAsset.ad_copy` の型を強化
- `content/page.tsx`: 広告コピーセクションを3プラットフォームカード（Google=青・Facebook=紺・Instagram=紫）横3列レイアウトに刷新。コピー完了をトースト通知（2秒で自動消灯）に変更

## 破壊的変更

既存の生成済み `ad_copy` データは旧構造のため新 UI では正しく表示されません。再生成が必要です。

## スクショ
<img width="1939" height="1171" alt="image" src="https://github.com/user-attachments/assets/5e8dbfd9-eaa5-4185-a6eb-d88dbad9203b" />


close #4 
