### PR TITLE
[Issue #1]施設登録済み画像を LP に転用し、画像スロットを 6 枠に拡張

### DIFF
--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -890,7 +890,7 @@ async def upload_lp_image(
         raise HTTPException(status_code=404, detail="クリエイティブアセットが見つかりません")
     
     # 画像タイプの検証
-    valid_types = ["hero", "feature", "ambiance"]
+    valid_types = ["hero", "feature", "feature1", "feature2", "feature3", "surrounding", "ambiance"]
     if image_type not in valid_types:
         raise HTTPException(
             status_code=400, 

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -29,6 +29,70 @@ AD_IMAGE_TYPE_PREFERENCES = {
     "display_vertical": ("bath", "room", "interior", "sightseeing", "other"),
 }
 
+# LP 画像スロットと割り当て優先 type の順
+_LP_IMAGE_SLOT_PREFERENCES: Dict[str, Tuple] = {
+    "hero":        ("exterior", "lobby", "interior", "other"),
+    "feature1":    ("room", "interior", "other"),
+    "feature2":    ("bath", "room", "other"),
+    "feature3":    ("cuisine", "restaurant", "other"),
+    "surrounding": ("sightseeing", "exterior", "other"),
+    "ambiance":    ("interior", "other", "exterior"),
+}
+
+
+def _map_facility_images_for_lp(hotel: Hotel) -> Dict[str, str]:
+    """
+    施設画像（facility_images）を LP 用スロットにマッピングして返す。
+
+    各スロットに type の優先順で未使用画像を割り当てる。
+    有効な画像（/static/hotel_images/ から始まる URL）のみを対象とし、
+    1枚の画像を複数スロットに重複使用しない。
+
+    Returns:
+        {slot_name: url} の辞書。有効な画像が 0 件なら空辞書を返す。
+    """
+    images = hotel.facility_images or []
+    valid_images = [
+        item for item in images
+        if isinstance(item, dict)
+        and isinstance(item.get("url"), str)
+        and item["url"].startswith("/static/hotel_images/")
+    ]
+    if not valid_images:
+        return {}
+
+    valid_images.sort(key=lambda x: (x.get("order", 9999), str(x.get("key", ""))))
+
+    used_keys: set = set()
+    result: Dict[str, str] = {}
+
+    for slot, preferences in _LP_IMAGE_SLOT_PREFERENCES.items():
+        chosen = None
+        for preferred_type in preferences:
+            for item in valid_images:
+                if item.get("type") != preferred_type:
+                    continue
+                if item.get("key") in used_keys:
+                    continue
+                chosen = item
+                break
+            if chosen:
+                break
+
+        # 優先 type で見つからなければ未使用の先頭画像を使う
+        if not chosen:
+            for item in valid_images:
+                if item.get("key") not in used_keys:
+                    chosen = item
+                    break
+
+        if chosen:
+            result[slot] = chosen["url"]
+            if chosen.get("key"):
+                used_keys.add(chosen["key"])
+
+    return result
+
 
 def _select_ad_reference_images(hotel: Hotel) -> Tuple[Dict[str, dict], str]:
     """施設画像（S3配信URL）を広告枠ごとの参照画像として選定する。"""
@@ -197,14 +261,23 @@ async def generate_creative_assets_authenticated(
         ota_text = {}
         ota_text_prompt = None
         
-        # LP用画像を先に生成（LPで使用するため）
+        # LP用画像: 施設登録済み画像を優先して転用し、未登録の場合のみ AI 生成
         if request.generate_lp:
-            lp_image_urls, lp_image_gen_prompt = await generator.generate_lp_images(
-                marketing_plan=marketing_plan,
-                llm_client=llm_client_image,
-                hotel_id=hotel_id
-            )
-        
+            mapped = _map_facility_images_for_lp(hotel)
+            if mapped:
+                lp_image_urls = mapped
+                lp_image_gen_prompt = (
+                    "【LP画像】施設画像（facility_images）をスロットにマッピングして使用しました。\n"
+                    + "\n".join(f"- {slot}: {url}" for slot, url in mapped.items())
+                )
+            else:
+                # 施設画像未登録の場合のみ AI 生成にフォールバック
+                lp_image_urls, lp_image_gen_prompt = await generator.generate_lp_images(
+                    marketing_plan=marketing_plan,
+                    llm_client=llm_client_image,
+                    hotel_id=hotel_id
+                )
+
         # 広告用画像を生成
         if request.generate_images:
             selected_refs, selection_log = _select_ad_reference_images(hotel)
@@ -239,12 +312,13 @@ async def generate_creative_assets_authenticated(
         
         # LP生成（LP用画像URLとホテル情報を渡す）
         if request.generate_lp:
-            # 成功した画像URLのみを抽出（エラー情報を除外）
-            valid_lp_image_urls = {}
-            for key, value in lp_image_urls.items():
-                if isinstance(value, str) and value.startswith("/static/"):
-                    valid_lp_image_urls[key] = value
-            
+            # 有効な静的URLのみを抽出（エラー情報・不正値を除外）
+            valid_lp_image_urls = {
+                key: value
+                for key, value in lp_image_urls.items()
+                if isinstance(value, str) and value.startswith("/static/")
+            }
+
             lp_code, lp_prompt = await generator.generate_landing_page(
                 marketing_plan=marketing_plan,
                 llm_client=llm_client_lp,

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -247,8 +247,8 @@ async def generate_creative_assets_authenticated(
         llm_client = get_llm_client()
         # LP生成用（gemini-3-pro-preview）
         llm_client_lp = get_llm_client(model_name="gemini-3-pro-preview")
-        # 画像生成用（gemini-3-pro-image-preview）
-        llm_client_image = get_llm_client(model_name="gemini-3-pro-image-preview")
+        # 画像生成用
+        llm_client_image = get_llm_client(model_name="gemini-3.1-flash-image-preview")
         
         lp_code = None
         lp_prompt = None
@@ -566,7 +566,7 @@ async def generate_creative_assets(
     try:
         generator = CreativeGenerator()
         llm_client = get_llm_client()
-        llm_client_image = get_llm_client(model_name="gemini-3-pro-image-preview")
+        llm_client_image = get_llm_client(model_name="gemini-3.1-flash-image-preview")
         
         lp_code = None
         lp_prompt = None

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -479,8 +479,8 @@ async def save_lp_to_file(
         
         # 画像URLを取得（エラー情報を含まない実際の画像パスのみ）
         image_urls = {}
-        if asset.ad_image_urls:
-            for key, value in asset.ad_image_urls.items():
+        if asset.lp_image_urls:
+            for key, value in asset.lp_image_urls.items():
                 if isinstance(value, str) and value.startswith("/static/"):
                     image_urls[key] = value
         
@@ -566,7 +566,7 @@ async def generate_creative_assets(
     try:
         generator = CreativeGenerator()
         llm_client = get_llm_client()
-        llm_client_image = get_llm_client(model_name="gemini-3-pro-image-preview")
+        llm_client_image = get_llm_client(model_name="gemini-2.0-flash-exp")
         
         lp_code = None
         lp_prompt = None

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -566,7 +566,7 @@ async def generate_creative_assets(
     try:
         generator = CreativeGenerator()
         llm_client = get_llm_client()
-        llm_client_image = get_llm_client(model_name="gemini-2.0-flash-exp")
+        llm_client_image = get_llm_client(model_name="gemini-3-pro-image-preview")
         
         lp_code = None
         lp_prompt = None

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -938,26 +938,46 @@ async def upload_lp_image(
     lp_image_urls[image_type] = new_image_url
     asset.lp_image_urls = lp_image_urls
     
+    # 他スロットに割り当てられている画像パスを収集（フォールバック検出用）
+    other_slot_paths = set()
+    for key, val in lp_image_urls.items():
+        if key != image_type and isinstance(val, str):
+            other_slot_paths.add(val)
+
     # 画像パス置換用のヘルパー関数
     def replace_image_path(content: str, old_name: str | None, new_name: str) -> str:
         """HTMLコンテンツ内の画像パスを置換"""
+        new_relative = f"./{new_name}"
+        content_before = content
+
+        # 1) 旧パスのフルパスで置換（施設画像 /static/hotel_images/... 等に対応）
+        if old_image_path:
+            content = content.replace(old_image_path, new_relative)
+
+        # 2) ファイル名ベースの置換
         if old_name:
-            # 古いファイル名を新しいファイル名に置換（相対パス形式）
-            content = content.replace(f"./{old_name}", f"./{new_name}")
-            content = content.replace(f'"{old_name}"', f'"./{new_name}"')
-            content = content.replace(f"'{old_name}'", f"'./{new_name}'")
-            # 絶対パス形式も対応
-            content = content.replace(f"/static/lp/{hotel_id}/{old_name}", f"./{new_name}")
-        
-        # 画像タイプに基づいた正規表現パターンでも置換（より確実な置換）
-        # hero_XXXXXXXX.jpg, feature_XXXXXXXX.png などのパターンに対応
-        pattern = rf"\./{image_type}_[a-f0-9]+\.(jpg|jpeg|png|webp)"
-        content = re.sub(pattern, f"./{new_name}", content)
-        
-        # url('...') パターンにも対応
-        pattern_url = rf"url\(['\"]?\./{image_type}_[a-f0-9]+\.(jpg|jpeg|png|webp)['\"]?\)"
-        content = re.sub(pattern_url, f"url('./{new_name}')", content)
-        
+            content = content.replace(f"./{old_name}", new_relative)
+            content = content.replace(f'"{old_name}"', f'"{new_relative}"')
+            content = content.replace(f"'{old_name}'", f"'{new_relative}'")
+            content = content.replace(f"/static/lp/{hotel_id}/{old_name}", new_relative)
+
+        # 3) 画像タイプに基づいた正規表現パターンでも置換
+        pattern = rf"\./{re.escape(image_type)}_[a-f0-9]+\.(jpg|jpeg|png|webp)"
+        content = re.sub(pattern, new_relative, content)
+
+        pattern_url = rf"url\(['\"]?\./{re.escape(image_type)}_[a-f0-9]+\.(jpg|jpeg|png|webp)['\"]?\)"
+        content = re.sub(pattern_url, f"url('{new_relative}')", content)
+
+        # 4) フォールバック: 上記で置換が発生しなかった場合、
+        #    HTML内の hotel_images パスのうち他スロットに属さないものを置換
+        if content == content_before:
+            hotel_img_pattern = rf'/static/hotel_images/{hotel_id}/[^\s"\')\]]+\.\w+'
+            orphan_paths = set(re.findall(hotel_img_pattern, content))
+            orphan_paths -= other_slot_paths
+            for orphan in orphan_paths:
+                print(f"フォールバック置換: {orphan} → {new_relative}")
+                content = content.replace(orphan, new_relative)
+
         return content
     
     # DB内のlp_source_codeを更新

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -82,6 +82,9 @@ class CreativeGenerator:
                 if f"/static/lp/{hotel_id}/" in url:
                     filename = url.split("/")[-1]
                     relative_path = f"./{filename}"
+                elif "/hotel_images/" in url:
+                    # 施設画像は S3 経由のため絶対パスのまま（変換しない）
+                    relative_path = url
                 else:
                     # その他の画像（広告用など）は../で上に上がる
                     # /static/generated_images/5/xxx.png -> ../generated_images/5/xxx.png
@@ -146,7 +149,7 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
         response = await llm_client.generate_text(
             user_prompt=prompt,
             system_prompt=system_prompt,
-            max_tokens=8000
+            max_tokens=16000
         )
         
         # コードブロックを抽出
@@ -800,33 +803,39 @@ The image should make viewers want to book immediately.""",
 公式サイト: {hotel_info.get('website', '') or '掲載なし'}
 """
         
+        # 画像スロットの役割ラベル（6スロット対応）
+        _LP_SLOT_LABELS = {
+            "hero":        "ヒーロー画像（施設外観・玄関などメインビジュアル）",
+            "feature1":    "客室紹介画像",
+            "feature2":    "風呂・温泉紹介画像",
+            "feature3":    "料理・食事紹介画像",
+            "surrounding": "周辺観光・景観画像",
+            "ambiance":    "雰囲気・内装画像",
+            # 旧スロット名との後方互換
+            "feature":     "特徴紹介画像",
+        }
+
         # 画像セクション
         image_section = ""
         if image_urls and len(image_urls) > 0:
-            image_section = """
-【使用する画像 - 必ず以下の画像をHTMLに埋め込んでください】
-"""
+            image_section = "【使用する画像 - 必ず以下の画像をHTMLに埋め込んでください】\n"
             for img_type, img_path in image_urls.items():
                 # パスをファイル名のみの相対パス（./xxx.png）に変換
-                if isinstance(img_path, str) and "/" in img_path:
+                if isinstance(img_path, str) and "/hotel_images/" in img_path:
+                    # 施設画像は S3 カスタムハンドラー経由のため絶対パスのまま使用
+                    relative_path = img_path
+                elif isinstance(img_path, str) and "/" in img_path:
                     filename = img_path.split("/")[-1]
                     relative_path = f"./{filename}"
                 else:
                     relative_path = img_path
-                
-                if img_type == "hero":
-                    image_section += f"- ヒーロー画像（メインビジュアル）: {relative_path}\n"
-                elif img_type == "feature":
-                    image_section += f"- 特徴紹介画像: {relative_path}\n"
-                elif img_type == "ambiance":
-                    image_section += f"- 雰囲気・ディテール画像: {relative_path}\n"
-                else:
-                    image_section += f"- {img_type}: {relative_path}\n"
-            
+                label = _LP_SLOT_LABELS.get(img_type, img_type)
+                image_section += f"- {label}: {relative_path}\n"
+
             image_section += """
 ※ 上記の画像パス（./xxx.png形式）をそのままimgタグのsrc属性に使用してください
 ※ ヒーロー画像はヒーローセクションの背景または大きな画像として使用
-※ 特徴画像は特徴・特典セクションで使用
+※ 客室・風呂・料理・周辺観光画像はそれぞれ対応するセクションで使用
 ※ 雰囲気画像は追加のビジュアルとして適宜使用
 """
         else:

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -6,7 +6,6 @@ from typing import Dict, Optional, Tuple
 from app.models import MarketingPlan
 from app.core.language import get_language_instruction, get_language_name, is_japanese
 
-
 class CreativeGenerator:
     """クリエイティブアセット生成サービス"""
     
@@ -82,8 +81,8 @@ class CreativeGenerator:
                 if f"/static/lp/{hotel_id}/" in url:
                     filename = url.split("/")[-1]
                     relative_path = f"./{filename}"
-                elif "/hotel_images/" in url:
-                    # 施設画像は S3 経由のため絶対パスのまま（変換しない）
+                elif "/hotel_images/" in url or "/generated_images/" in url:
+                    # S3 経由で配信される画像は絶対パスのまま（変換しない）
                     relative_path = url
                 else:
                     # その他の画像（広告用など）は../で上に上がる
@@ -193,12 +192,12 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
             (画像URL辞書, 生成ログ) のタプル
         """
         # 画像保存ディレクトリを作成
-        image_dir = os.path.join("static", save_subdir, str(hotel_id))
+        image_dir = os.path.join(self.static_dir, save_subdir, str(hotel_id))
         os.makedirs(image_dir, exist_ok=True)
-        
+
         image_urls = {}
         generation_log = []
-        
+
         for image_type, config in image_configs.items():
             try:
                 # 画像を生成
@@ -206,17 +205,16 @@ HTML + CSS + JavaScript のシングルファイルで実装してください�
                     prompt=config["prompt"],
                     aspect_ratio=config.get("aspect_ratio", "16:9")
                 )
-                
+
                 # ファイル拡張子を決定
                 ext = "png" if "png" in mime_type else "jpg"
                 filename = f"{prefix}{image_type}_{uuid.uuid4().hex[:8]}.{ext}"
                 filepath = os.path.join(image_dir, filename)
-                
+
                 # 画像を保存
                 with open(filepath, "wb") as f:
                     f.write(image_data)
-                
-                # URLパスを保存（save_subdirに応じたパス）
+
                 image_urls[image_type] = f"/static/{save_subdir}/{hotel_id}/{filename}"
                 generation_log.append(f"{image_type}: 生成成功")
                 

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -42,7 +42,7 @@ export default function ContentPage() {
   
   // 画像アップロード確認モーダル関連のstate
   const [pendingImageUpload, setPendingImageUpload] = useState<{
-    imageType: "hero" | "feature" | "ambiance";
+    imageType: string;
     file: File;
     previewUrl: string;
   } | null>(null);
@@ -187,7 +187,7 @@ export default function ContentPage() {
   // LP画像をアップロード
   const handleImageUpload = async (
     assetId: number,
-    imageType: "hero" | "feature" | "ambiance",
+    imageType: string,
     file: File
   ) => {
     setUploadingImage(imageType);
@@ -556,7 +556,7 @@ export default function ContentPage() {
                         {Object.entries(currentAsset.lp_image_urls).map(([key, value]) => {
                           const imageValue = value as Record<string, unknown> | string | null;
                           const isError = typeof imageValue === "object" && imageValue !== null && "error" in imageValue;
-                          const isValidType = ["hero", "feature", "ambiance"].includes(key);
+                          const isValidType = ["hero", "feature", "feature1", "feature2", "feature3", "surrounding", "ambiance"].includes(key);
                           const isUploading = uploadingImage === key;
                           
                           return (
@@ -581,7 +581,7 @@ export default function ContentPage() {
                                       // ファイルを選択したらプレビューを表示（即座にアップロードしない）
                                       const previewUrl = URL.createObjectURL(file);
                                       setPendingImageUpload({
-                                        imageType: key as "hero" | "feature" | "ambiance",
+                                        imageType: key,
                                         file,
                                         previewUrl,
                                       });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1552,7 +1552,7 @@ export const marketingApi = {
   async uploadLpImage(
     hotelId: number,
     assetId: number,
-    imageType: "hero" | "feature" | "ambiance",
+    imageType: string,
     file: File
   ): Promise<{
     message: string;


### PR DESCRIPTION
## 概要

- LP 生成時に施設登録時にアップロード済みの画像（`facility_images`）を使用
- LP の画像スロットを 3 枠 → 6 枠に拡張（hero / feature1-3 / surrounding / ambiance）
- 施設画像が未登録の場合のみ AI 生成にフォールバック
- LP 保存時の画像 URL 参照を `lp_image_urls` に分離（広告画像と混在を解消）
- LP 生成の max_tokens を 8,000 → 16,000 に拡張

## 変更点

### `backend/app/api/creative.py`
- `_LP_IMAGE_SLOT_PREFERENCES` を定義し、スロットごとに割り当てる画像タイプの優先順を設定
- `_map_facility_images_for_lp()` を追加：施設画像を重複なくスロットにマッピング
- LP 生成フローで施設画像が存在する場合は AI 生成をスキップ
- `save_lp_to_file` で参照する画像 URL を `ad_image_urls` → `lp_image_urls` に変更

### `backend/app/services/creative_generator.py`
- LP 生成プロンプトの画像スロットラベルを 6 枠対応に更新
- 施設画像（`/hotel_images/`）は絶対パスのまま LP に埋め込むよう修正
- `_convert_image_paths_to_relative` で `/hotel_images/` および `/generated_images/` パスは変換しないよう対応
- `_generate_images_with_configs` の保存先パスを `self.static_dir` ベースに修正

## 動作確認

- [x] 施設画像が登録済みの場合、LP に facility_images が使用されることを確認
- [x] 施設画像が未登録の場合、AI 生成画像が使用されることを確認
- [x] 6 スロット（hero / feature1-3 / surrounding / ambiance）が正しくマッピングされることを確認
- [x] `save_lp_to_file` 後、LP の画像パスが正しく解決されることを確認

## スクショ
<img width="1418" height="1344" alt="image" src="https://github.com/user-attachments/assets/a2ffea46-5591-4cef-8ff6-5df7d731f876" />
