### PR TITLE
[Issue #1 D. 宿・周辺情報] 宿の情報管理画面と LP 品質向上

### DIFF
--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -330,7 +330,8 @@ async def generate_creative_assets_authenticated(
                     "phone": hotel.phone,
                     "website": hotel.website,
                 },
-                image_urls=valid_lp_image_urls
+                image_urls=valid_lp_image_urls,
+                hotel_detail=hotel.hotel_detail or {}
             )
         
         # 広告コピー生成

--- a/backend/app/api/facility_hotels.py
+++ b/backend/app/api/facility_hotels.py
@@ -10,8 +10,9 @@ from pydantic import BaseModel
 from app.core.database import get_session
 from app.core.llm import get_llm_client
 from app.core.image_utils import save_facility_image, delete_facility_image_file
-from app.models import FacilityAdmin, FacilityAdminHotel, Hotel, FacilityAdminHotelRole
+from app.models import FacilityAdmin, FacilityAdminHotel, Hotel, FacilityAdminHotelRole, AnalysisSession
 from app.auth.dependencies import get_current_facility_admin
+from app.services.hotel_scrape_service import HotelScrapeService
 from sqlmodel import select
 
 router = APIRouter(prefix="/facility/hotels", tags=["Facility Hotels"])
@@ -827,6 +828,341 @@ async def update_hotel_assets(
     session.refresh(hotel)
     
     return hotel.hotel_assets
+
+
+# ============================================
+# 宿・周辺情報 API
+# ============================================
+
+class HotelDetailAttractionItem(BaseModel):
+    """周辺観光スポット1件"""
+    name: str
+    distance: str
+
+
+class HotelDetailSurrounding(BaseModel):
+    """周辺情報"""
+    description: str = ""
+    attractions: List[HotelDetailAttractionItem] = []
+
+
+class HotelStoryDetailResponse(BaseModel):
+    """宿・周辺情報レスポンス"""
+    story: str = ""
+    highlights: List[str] = []
+    surrounding: HotelDetailSurrounding = HotelDetailSurrounding()
+    access: str = ""
+
+
+class HotelDetailUpdateRequest(BaseModel):
+    """宿・周辺情報更新リクエスト"""
+    story: Optional[str] = None
+    highlights: Optional[List[str]] = None
+    surrounding: Optional[HotelDetailSurrounding] = None
+    access: Optional[str] = None
+
+
+@router.get("/{hotel_id}/detail", response_model=HotelStoryDetailResponse)
+async def get_hotel_detail(
+    hotel_id: int,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session)
+):
+    """宿のストーリー・周辺情報を取得"""
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id
+        )
+    ).first()
+
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    detail = hotel.hotel_detail or {}
+    surrounding_data = detail.get("surrounding", {})
+    return HotelStoryDetailResponse(
+        story=detail.get("story", ""),
+        highlights=detail.get("highlights", []),
+        surrounding=HotelDetailSurrounding(
+            description=surrounding_data.get("description", ""),
+            attractions=[
+                HotelDetailAttractionItem(
+                    name=a.get("name", ""),
+                    distance=a.get("distance", ""),
+                )
+                for a in surrounding_data.get("attractions", [])
+            ],
+        ),
+        access=detail.get("access", ""),
+    )
+
+
+@router.put("/{hotel_id}/detail", response_model=HotelStoryDetailResponse)
+async def update_hotel_detail(
+    hotel_id: int,
+    request: HotelDetailUpdateRequest,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session)
+):
+    """宿のストーリー・周辺情報を更新"""
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id
+        )
+    ).first()
+
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+
+    if permission.role not in [FacilityAdminHotelRole.owner, FacilityAdminHotelRole.editor]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="編集権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    current = dict(hotel.hotel_detail or {})
+    if request.story is not None:
+        current["story"] = request.story
+    if request.highlights is not None:
+        current["highlights"] = request.highlights
+    if request.surrounding is not None:
+        current["surrounding"] = {
+            "description": request.surrounding.description,
+            "attractions": [
+                {"name": a.name, "distance": a.distance}
+                for a in request.surrounding.attractions
+            ],
+        }
+    if request.access is not None:
+        current["access"] = request.access
+
+    hotel.hotel_detail = current
+    hotel.updated_at = datetime.utcnow()
+    flag_modified(hotel, "hotel_detail")
+    session.add(hotel)
+    session.commit()
+    session.refresh(hotel)
+
+    detail = hotel.hotel_detail or {}
+    surrounding_data = detail.get("surrounding", {})
+    return HotelStoryDetailResponse(
+        story=detail.get("story", ""),
+        highlights=detail.get("highlights", []),
+        surrounding=HotelDetailSurrounding(
+            description=surrounding_data.get("description", ""),
+            attractions=[
+                HotelDetailAttractionItem(
+                    name=a.get("name", ""),
+                    distance=a.get("distance", ""),
+                )
+                for a in surrounding_data.get("attractions", [])
+            ],
+        ),
+        access=detail.get("access", ""),
+    )
+
+
+class HotelAutoFillResponse(BaseModel):
+    """公式サイト自動入力レスポンス"""
+    highlights: List[str] = []
+    surrounding: HotelDetailSurrounding = HotelDetailSurrounding()
+    access: str = ""
+
+
+@router.post("/{hotel_id}/detail/auto-fill", response_model=HotelAutoFillResponse)
+async def auto_fill_hotel_detail(
+    hotel_id: int,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session),
+):
+    """公式サイトURLからハイライト・周辺情報・アクセスを自動取得"""
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id,
+        )
+    ).first()
+
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    if not hotel.website:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="公式サイトのURLが設定されていません",
+        )
+
+    result = await HotelScrapeService.scrape_hotel_info(hotel.website, hotel.name)
+
+    surrounding_raw = result.get("surrounding", {})
+    attractions = [
+        HotelDetailAttractionItem(
+            name=a.get("name", ""),
+            distance=a.get("distance", ""),
+        )
+        for a in surrounding_raw.get("attractions", [])
+    ]
+
+    return HotelAutoFillResponse(
+        highlights=result.get("highlights", []),
+        surrounding=HotelDetailSurrounding(
+            description=surrounding_raw.get("description", ""),
+            attractions=attractions,
+        ),
+        access=result.get("access", ""),
+    )
+
+
+class SurroundingFromMarketResponse(BaseModel):
+    """市場データから生成した周辺情報"""
+    surrounding: HotelDetailSurrounding = HotelDetailSurrounding()
+
+
+@router.post("/{hotel_id}/detail/fill-surrounding-from-market", response_model=SurroundingFromMarketResponse)
+async def fill_surrounding_from_market(
+    hotel_id: int,
+    facility_admin: FacilityAdmin = Depends(get_current_facility_admin),
+    session: Session = Depends(get_session),
+):
+    """市場分析データ（地域トレンド）から周辺観光情報を生成"""
+    permission = session.exec(
+        select(FacilityAdminHotel).where(
+            FacilityAdminHotel.facility_admin_id == facility_admin.id,
+            FacilityAdminHotel.hotel_id == hotel_id,
+        )
+    ).first()
+
+    if permission is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この施設へのアクセス権限がありません",
+        )
+
+    hotel = session.exec(select(Hotel).where(Hotel.id == hotel_id)).first()
+    if hotel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="施設が見つかりません",
+        )
+
+    analysis = session.exec(
+        select(AnalysisSession).where(AnalysisSession.hotel_id == hotel_id)
+    ).first()
+
+    if analysis is None or not analysis.regional_trends:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="市場分析データがありません。先にマーケティングAIの「市場を知る」で分析を実行してください。",
+        )
+
+    import json, re
+
+    system_prompt = (
+        "あなたは宿泊施設のマーケティング専門家です。"
+        "地域トレンドの分析文から、宿泊施設の公式ウェブサイトで使えるような"
+        "周辺エリアの説明文と観光スポット情報を抽出・整形してください。"
+    )
+
+    user_prompt = f"""以下は「{hotel.name}」が立地するエリアの地域トレンド分析です。
+
+---
+{analysis.regional_trends}
+---
+
+この分析文から、宿泊施設ウェブサイト向けに以下のJSON形式で周辺情報を整形してください：
+
+{{
+  "surrounding": {{
+    "description": "周辺エリアを宿泊客に伝える説明文（150〜300文字程度）",
+    "attractions": [
+      {{"name": "観光スポット名", "distance": "目安の距離・時間（例：車で20分）"}}
+    ]
+  }}
+}}
+
+ルール:
+- description は旅行者向けの魅力的な文章にする
+- attractions は分析文中で言及されている具体的なスポット名のみ抽出（最大8件）
+- 距離情報がない場合は空文字""にする
+- 純粋なJSONのみを返す（コードブロック不要）"""
+
+    try:
+        llm = get_llm_client(model_name="gemini-2.5-flash-lite")
+        raw = await llm.generate_structured_output(
+            user_prompt=user_prompt,
+            system_prompt=system_prompt,
+            max_tokens=2048,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="AI生成エラーが発生しました",
+        )
+
+    try:
+        cleaned = re.sub(r"```(?:json)?\s*", "", raw).strip().rstrip("`").strip()
+        result = json.loads(cleaned)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="AI応答のパースに失敗しました",
+        )
+
+    surrounding_raw = result.get("surrounding", {})
+    if not isinstance(surrounding_raw, dict):
+        surrounding_raw = {}
+
+    attractions_raw = surrounding_raw.get("attractions", [])
+    if not isinstance(attractions_raw, list):
+        attractions_raw = []
+
+    attractions = [
+        HotelDetailAttractionItem(
+            name=str(a.get("name", "")),
+            distance=str(a.get("distance", "")),
+        )
+        for a in attractions_raw
+        if isinstance(a, dict)
+    ]
+
+    return SurroundingFromMarketResponse(
+        surrounding=HotelDetailSurrounding(
+            description=str(surrounding_raw.get("description", "")),
+            attractions=attractions,
+        )
+    )
 
 
 @router.post("/{hotel_id}/assets/extract-from-image", response_model=dict)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -133,7 +133,22 @@ class Hotel(SQLModel, table=True):
     
     # 施設画像（最大10件）。各要素: key, url, description, type, order
     facility_images: list = Field(default_factory=list, sa_column=Column(JSON))
-    
+
+    # 宿のストーリー・周辺情報（JSON形式）
+    # {
+    #   "story":      "創業〇〇年。山の麓に佇む...",
+    #   "highlights": ["源泉かけ流し", "地産地消料理"],
+    #   "surrounding": {
+    #     "description": "南アルプスの麓に位置し...",
+    #     "attractions": [
+    #       {"name": "○○温泉郷", "distance": "徒歩5分"},
+    #       {"name": "△△神社",   "distance": "車10分"}
+    #     ]
+    #   },
+    #   "access": "新宿駅から特急で2時間。送迎あり（要予約）"
+    # }
+    hotel_detail: dict = Field(default_factory=dict, sa_column=Column(JSON))
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -103,7 +103,8 @@ class CreativeGenerator:
         llm_client,
         cv_url: str = None,
         hotel_info: Dict = None,
-        image_urls: Dict[str, str] = None
+        image_urls: Dict[str, str] = None,
+        hotel_detail: Dict = None
     ) -> Tuple[str, str]:
         """
         ランディングページのコードを生成
@@ -121,7 +122,7 @@ class CreativeGenerator:
         # ターゲット言語を取得
         target_language = self._get_target_language(marketing_plan)
         
-        prompt = self._create_lp_generation_prompt(marketing_plan, cv_url, hotel_info, image_urls, target_language)
+        prompt = self._create_lp_generation_prompt(marketing_plan, cv_url, hotel_info, image_urls, target_language, hotel_detail)
         
         # 言語に応じたシステムプロンプトを生成
         language_instruction = get_language_instruction(target_language)
@@ -794,19 +795,20 @@ The image should make viewers want to book immediately.""",
         return ad_copy, prompt, warnings
     
     def _create_lp_generation_prompt(
-        self, 
-        plan: MarketingPlan, 
+        self,
+        plan: MarketingPlan,
         cv_url: str = None,
         hotel_info: Dict = None,
         image_urls: Dict[str, str] = None,
-        target_language: str = "ja"
+        target_language: str = "ja",
+        hotel_detail: Dict = None
     ) -> str:
         """LP生成プロンプトを作成"""
-        
+
         # 言語指示を作成
         language_instruction = get_language_instruction(target_language)
         language_name = get_language_name(target_language)
-        
+
         # ホテル情報セクション
         hotel_section = ""
         if hotel_info:
@@ -818,6 +820,39 @@ The image should make viewers want to book immediately.""",
 公式サイト: {hotel_info.get('website', '') or '掲載なし'}
 """
         
+        # 宿のストーリー・周辺情報セクション
+        hotel_detail_section = ""
+        if hotel_detail:
+            story = hotel_detail.get("story", "").strip()
+            highlights = hotel_detail.get("highlights", [])
+            surrounding = hotel_detail.get("surrounding", {})
+            surrounding_desc = surrounding.get("description", "").strip()
+            attractions = surrounding.get("attractions", [])
+            access = hotel_detail.get("access", "").strip()
+
+            parts = []
+            if story:
+                parts.append(f"【宿のストーリー・こだわり】\n{story}")
+            if highlights:
+                bullet = "\n".join(f"- {h}" for h in highlights)
+                parts.append(f"【宿のハイライト】\n{bullet}")
+            if surrounding_desc or attractions:
+                surr_lines = ["【周辺観光情報】"]
+                if surrounding_desc:
+                    surr_lines.append(f"エリア説明: {surrounding_desc}")
+                if attractions:
+                    surr_lines.append("観光スポット:")
+                    for a in attractions:
+                        name = a.get("name", "")
+                        distance = a.get("distance", "")
+                        surr_lines.append(f"  - {name}（{distance}）")
+                parts.append("\n".join(surr_lines))
+            if access:
+                parts.append(f"【アクセス】\n{access}")
+
+            if parts:
+                hotel_detail_section = "\n\n".join(parts) + "\n"
+
         # 画像スロットの役割ラベル（6スロット対応）
         _LP_SLOT_LABELS = {
             "hero":        "ヒーロー画像（施設外観・玄関などメインビジュアル）",
@@ -891,6 +926,7 @@ The image should make viewers want to book immediately.""",
         return f"""
 以下のマーケティングプランに基づいて、宿泊施設のランディングページを作成してください。
 {hotel_section}
+{hotel_detail_section}
 【プラン情報】
 プラン名: {plan.plan_name}
 コンセプト: {plan.concept}

--- a/backend/app/services/hotel_scrape_service.py
+++ b/backend/app/services/hotel_scrape_service.py
@@ -1,0 +1,163 @@
+"""宿の公式サイトからハイライト・周辺情報・アクセスを自動取得するサービス"""
+import json
+import re
+from html.parser import HTMLParser
+
+import httpx
+
+from app.core.llm import get_llm_client
+
+_DEFAULT_RESULT = {
+    "highlights": [],
+    "surrounding": {"description": "", "attractions": []},
+    "access": "",
+}
+
+_USER_AGENT = (
+    "Mozilla/5.0 (compatible; MarketingPlannerBot/1.0; +https://example.com/bot)"
+)
+
+
+class _TextExtractor(HTMLParser):
+    """<script> / <style> を除外してテキストを抽出する HTMLParser"""
+
+    def __init__(self):
+        super().__init__()
+        self._skip = False
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style", "noscript"):
+            self._skip = True
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style", "noscript"):
+            self._skip = False
+
+    def handle_data(self, data):
+        if not self._skip:
+            stripped = data.strip()
+            if stripped:
+                self._parts.append(stripped)
+
+    def get_text(self) -> str:
+        return "\n".join(self._parts)
+
+
+def _extract_text(html: str) -> str:
+    parser = _TextExtractor()
+    try:
+        parser.feed(html)
+    except Exception:
+        pass
+    return parser.get_text()
+
+
+class HotelScrapeService:
+    @staticmethod
+    async def scrape_hotel_info(website_url: str, hotel_name: str) -> dict:
+        """
+        公式サイトからホテル情報をスクレイプして構造化JSONで返す。
+
+        Args:
+            website_url: ホテル公式サイトURL
+            hotel_name:  ホテル名（プロンプトに使用）
+
+        Returns:
+            {highlights, surrounding: {description, attractions}, access}
+        """
+        # 1. HTMLを取得
+        try:
+            async with httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                headers={"User-Agent": _USER_AGENT},
+            ) as client:
+                response = await client.get(website_url)
+                html = response.text
+        except Exception:
+            return dict(_DEFAULT_RESULT)
+
+        # 2. テキスト抽出 → 最大8,000文字
+        text = _extract_text(html)[:8000]
+
+        if not text.strip():
+            return dict(_DEFAULT_RESULT)
+
+        # 3. Gemini で構造化JSON生成
+        system_prompt = (
+            "あなたは宿泊施設のウェブサイト情報を整理するエキスパートです。"
+            "ウェブサイトのテキストを読み取り、宿のハイライト・周辺情報・アクセス情報を"
+            "指定のJSON形式で返してください。"
+            "情報が見つからないフィールドは空値（空文字列または空配列）にしてください。"
+            "推測で情報を作らず、サイトに記載されている内容のみを使用してください。"
+        )
+
+        user_prompt = f"""以下は「{hotel_name}」の公式サイトから取得したテキストです。
+
+---
+{text}
+---
+
+このテキストを元に、次のJSON形式で情報を抽出してください：
+{{
+  "highlights": ["宿の特徴フレーズ1", "宿の特徴フレーズ2"],
+  "surrounding": {{
+    "description": "周辺エリアの説明文",
+    "attractions": [
+      {{"name": "観光スポット名", "distance": "距離（例：車で15分）"}}
+    ]
+  }},
+  "access": "アクセス情報テキスト"
+}}
+
+ルール:
+- highlights は最大8個の短いフレーズ
+- attractions は最大10件
+- 情報がない場合は空値（[]、""）を返す
+- 純粋なJSONのみを返す（コードブロック不要）"""
+
+        try:
+            llm = get_llm_client(model_name="gemini-2.5-flash-lite")
+            raw = await llm.generate_structured_output(
+                user_prompt=user_prompt,
+                system_prompt=system_prompt,
+                max_tokens=2048,
+            )
+        except Exception:
+            return dict(_DEFAULT_RESULT)
+
+        # 4. JSONパース
+        try:
+            cleaned = re.sub(r"```(?:json)?\s*", "", raw).strip().rstrip("`").strip()
+            result = json.loads(cleaned)
+        except Exception:
+            return dict(_DEFAULT_RESULT)
+
+        # 5. 構造を保証して返す
+        highlights = result.get("highlights", [])
+        if not isinstance(highlights, list):
+            highlights = []
+
+        surrounding_raw = result.get("surrounding", {})
+        if not isinstance(surrounding_raw, dict):
+            surrounding_raw = {}
+
+        attractions_raw = surrounding_raw.get("attractions", [])
+        if not isinstance(attractions_raw, list):
+            attractions_raw = []
+
+        attractions = [
+            {"name": str(a.get("name", "")), "distance": str(a.get("distance", ""))}
+            for a in attractions_raw
+            if isinstance(a, dict)
+        ]
+
+        return {
+            "highlights": [str(h) for h in highlights if h],
+            "surrounding": {
+                "description": str(surrounding_raw.get("description", "")),
+                "attractions": attractions,
+            },
+            "access": str(result.get("access", "")),
+        }

--- a/backend/migrations/versions/007_add_hotel_detail.py
+++ b/backend/migrations/versions/007_add_hotel_detail.py
@@ -1,0 +1,48 @@
+"""Add hotel_detail column to hotels
+
+Revision ID: 007_add_hotel_detail
+Revises: 006_add_facility_images
+Create Date: 2026-03-04
+
+宿のストーリー・周辺情報を保持する hotel_detail カラムを hotels テーブルに追加
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '007_add_hotel_detail'
+down_revision: Union[str, None] = '006_add_facility_images'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """hotelsテーブルに hotel_detail カラムを追加（既存の場合はスキップ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'hotels' AND column_name = 'hotel_detail'"
+        )
+    ).scalar()
+    if result is None:
+        op.add_column(
+            'hotels',
+            sa.Column('hotel_detail', postgresql.JSONB(), nullable=True, server_default='{}')
+        )
+
+
+def downgrade() -> None:
+    """hotel_detail カラムを削除（存在する場合のみ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'hotels' AND column_name = 'hotel_detail'"
+        )
+    ).scalar()
+    if result is not None:
+        op.drop_column('hotels', 'hotel_detail')

--- a/backend/tests/test_hotel_detail.py
+++ b/backend/tests/test_hotel_detail.py
@@ -1,0 +1,405 @@
+"""
+宿の情報 API と LP プロンプト生成のテスト
+
+確認項目:
+- hotel_detail カラムが存在する（DB スキーマ）
+- GET/PUT /facility/hotels/{id}/detail で入力・保存できる
+- POST /detail/auto-fill: website 設定済みで動作、未設定で 400
+- POST /detail/fill-surrounding-from-market: 市場分析済みで動作、未実施で 400
+- LP 生成プロンプトに hotel_detail の各フィールドが含まれる
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models import (
+    AnalysisSession,
+    Hotel,
+    MarketingPlan,
+    PlanStatus,
+)
+from app.services.creative_generator import CreativeGenerator
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_plan() -> MarketingPlan:
+    """DB 不要な最小 MarketingPlan オブジェクト（プロンプト生成テスト用）"""
+    return MarketingPlan(
+        id=1,
+        analysis_session_id=1,
+        status=PlanStatus.draft,
+        plan_name="テストプラン",
+        concept="テストコンセプト",
+        target_audience={},
+        price_range={},
+        benefits={},
+        strategy_3c={},
+        strategy_pest={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. DB スキーマ: hotel_detail カラムの存在確認
+# ---------------------------------------------------------------------------
+
+class TestHotelDetailSchema:
+    def test_hotel_detail_column_exists_with_empty_default(self, session: Session):
+        """Hotel モデルに hotel_detail カラムが存在し、デフォルトは空 dict"""
+        hotel = Hotel(name="スキーマテスト旅館", address="東京都テスト区")
+        session.add(hotel)
+        session.commit()
+        session.refresh(hotel)
+
+        assert hasattr(hotel, "hotel_detail")
+        assert hotel.hotel_detail == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. GET /facility/hotels/{id}/detail
+# ---------------------------------------------------------------------------
+
+class TestGetHotelDetail:
+    def test_returns_empty_defaults(
+        self, client: TestClient, auth_headers: dict, sample_hotel: Hotel
+    ):
+        """未入力の場合、各フィールドが空のデフォルト値で返る"""
+        response = client.get(
+            f"/facility/hotels/{sample_hotel.id}/detail",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["story"] == ""
+        assert data["highlights"] == []
+        assert data["surrounding"]["description"] == ""
+        assert data["surrounding"]["attractions"] == []
+        assert data["access"] == ""
+
+    def test_requires_auth(self, client: TestClient, sample_hotel: Hotel):
+        """認証なしでアクセスすると 401 または 403"""
+        response = client.get(f"/facility/hotels/{sample_hotel.id}/detail")
+        assert response.status_code in (401, 403)
+
+    def test_forbidden_for_unrelated_hotel(
+        self, client: TestClient, auth_headers: dict, session: Session
+    ):
+        """権限のない施設では 403"""
+        other = Hotel(name="他の旅館", address="大阪府")
+        session.add(other)
+        session.commit()
+        session.refresh(other)
+
+        response = client.get(
+            f"/facility/hotels/{other.id}/detail",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 3. PUT /facility/hotels/{id}/detail
+# ---------------------------------------------------------------------------
+
+class TestUpdateHotelDetail:
+    def test_update_all_fields(
+        self, client: TestClient, auth_headers: dict, sample_hotel: Hotel
+    ):
+        """全フィールドを保存して正しく返る"""
+        payload = {
+            "story": "創業昭和30年。山の麓に佇む老舗旅館です。",
+            "highlights": ["源泉かけ流し", "地産地消料理", "貸切露天風呂"],
+            "surrounding": {
+                "description": "南アルプスの麓に位置する静かなエリアです。",
+                "attractions": [
+                    {"name": "○○温泉郷", "distance": "徒歩5分"},
+                    {"name": "△△神社", "distance": "車10分"},
+                ],
+            },
+            "access": "新宿駅から特急あずさで2時間。無料送迎あり（要予約）。",
+        }
+        response = client.put(
+            f"/facility/hotels/{sample_hotel.id}/detail",
+            json=payload,
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["story"] == payload["story"]
+        assert data["highlights"] == payload["highlights"]
+        assert data["surrounding"]["description"] == payload["surrounding"]["description"]
+        assert len(data["surrounding"]["attractions"]) == 2
+        assert data["surrounding"]["attractions"][0]["name"] == "○○温泉郷"
+        assert data["surrounding"]["attractions"][0]["distance"] == "徒歩5分"
+        assert data["access"] == payload["access"]
+
+    def test_update_partial_fields(
+        self, client: TestClient, auth_headers: dict, sample_hotel: Hotel
+    ):
+        """一部フィールドのみ指定した場合も正常に更新される"""
+        response = client.put(
+            f"/facility/hotels/{sample_hotel.id}/detail",
+            json={"highlights": ["温泉", "料理"]},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["highlights"] == ["温泉", "料理"]
+
+    def test_update_persists_on_get(
+        self, client: TestClient, auth_headers: dict, sample_hotel: Hotel
+    ):
+        """PUT 後に GET で同じ値が返る（永続化の確認）"""
+        payload = {"story": "永続化テストのストーリー", "access": "永続化テストのアクセス"}
+        client.put(
+            f"/facility/hotels/{sample_hotel.id}/detail",
+            json=payload,
+            headers=auth_headers,
+        )
+        response = client.get(
+            f"/facility/hotels/{sample_hotel.id}/detail",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["story"] == "永続化テストのストーリー"
+        assert data["access"] == "永続化テストのアクセス"
+
+
+# ---------------------------------------------------------------------------
+# 4. POST /facility/hotels/{id}/detail/auto-fill
+# ---------------------------------------------------------------------------
+
+class TestAutoFillHotelDetail:
+    def test_returns_400_when_website_not_set(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        session: Session,
+        sample_hotel: Hotel,
+    ):
+        """website 未設定の場合 400 とエラーメッセージを返す"""
+        sample_hotel.website = None
+        session.add(sample_hotel)
+        session.commit()
+
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/detail/auto-fill",
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "公式サイトのURLが設定されていません" in response.json()["detail"]
+
+    @patch("app.services.hotel_scrape_service.get_llm_client")
+    @patch("app.services.hotel_scrape_service.httpx.AsyncClient")
+    def test_returns_structured_data_when_website_set(
+        self,
+        mock_httpx_class,
+        mock_get_llm,
+        client: TestClient,
+        auth_headers: dict,
+        sample_hotel: Hotel,
+    ):
+        """website 設定済みの場合、スクレイプ＋LLM 結果を返す"""
+        # httpx のモック（async context manager）
+        mock_http_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.text = "<html><body>源泉かけ流し 自然豊か 新宿から2時間</body></html>"
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_httpx_class.return_value = mock_cm
+
+        # LLM のモック
+        llm_result = json.dumps({
+            "highlights": ["源泉かけ流し", "自然豊か"],
+            "surrounding": {
+                "description": "山に囲まれた静かなエリアです。",
+                "attractions": [{"name": "○○渓谷", "distance": "車15分"}],
+            },
+            "access": "新宿駅から特急で2時間。",
+        })
+        mock_llm = AsyncMock()
+        mock_llm.generate_structured_output = AsyncMock(return_value=llm_result)
+        mock_get_llm.return_value = mock_llm
+
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/detail/auto-fill",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data["highlights"], list)
+        assert len(data["highlights"]) > 0
+        assert "surrounding" in data
+        assert "description" in data["surrounding"]
+        assert "attractions" in data["surrounding"]
+        assert "access" in data
+
+    def test_forbidden_for_unrelated_hotel(
+        self, client: TestClient, auth_headers: dict, session: Session
+    ):
+        """権限のない施設では 403"""
+        other = Hotel(name="他の旅館3", address="京都府", website="https://example.com")
+        session.add(other)
+        session.commit()
+        session.refresh(other)
+
+        response = client.post(
+            f"/facility/hotels/{other.id}/detail/auto-fill",
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 5. POST /facility/hotels/{id}/detail/fill-surrounding-from-market
+# ---------------------------------------------------------------------------
+
+class TestFillSurroundingFromMarket:
+    def test_returns_400_when_no_analysis_session(
+        self, client: TestClient, auth_headers: dict, sample_hotel: Hotel
+    ):
+        """市場分析セッションが存在しない場合 400"""
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/detail/fill-surrounding-from-market",
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "市場分析データがありません" in response.json()["detail"]
+
+    def test_returns_400_when_regional_trends_is_null(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        session: Session,
+        sample_hotel: Hotel,
+    ):
+        """AnalysisSession があっても regional_trends が None なら 400"""
+        analysis = AnalysisSession(hotel_id=sample_hotel.id, regional_trends=None)
+        session.add(analysis)
+        session.commit()
+
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/detail/fill-surrounding-from-market",
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "市場分析データがありません" in response.json()["detail"]
+
+    @patch("app.api.facility_hotels.get_llm_client")
+    def test_returns_surrounding_when_trends_exist(
+        self,
+        mock_get_llm,
+        client: TestClient,
+        auth_headers: dict,
+        sample_analysis_session: AnalysisSession,
+        sample_hotel: Hotel,
+    ):
+        """regional_trends がある場合、surrounding を返す"""
+        llm_result = json.dumps({
+            "surrounding": {
+                "description": "観光地として人気の温泉エリアです。",
+                "attractions": [{"name": "有名温泉", "distance": "車20分"}],
+            }
+        })
+        mock_llm = AsyncMock()
+        mock_llm.generate_structured_output = AsyncMock(return_value=llm_result)
+        mock_get_llm.return_value = mock_llm
+
+        response = client.post(
+            f"/facility/hotels/{sample_hotel.id}/detail/fill-surrounding-from-market",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "surrounding" in data
+        assert isinstance(data["surrounding"]["description"], str)
+        assert isinstance(data["surrounding"]["attractions"], list)
+
+
+# ---------------------------------------------------------------------------
+# 6. LP 生成プロンプトへの hotel_detail 組み込み確認
+# ---------------------------------------------------------------------------
+
+class TestLpPromptIncludesHotelDetail:
+    """
+    _create_lp_generation_prompt() に hotel_detail を渡したとき、
+    各フィールドの内容がプロンプト文字列に含まれることを確認。
+    （LLM 呼び出しなし・純粋なユニットテスト）
+    """
+
+    def test_story_appears_in_prompt(self):
+        generator = CreativeGenerator()
+        prompt = generator._create_lp_generation_prompt(
+            plan=_make_plan(),
+            hotel_detail={"story": "創業昭和30年の老舗旅館", "highlights": [], "surrounding": {}, "access": ""},
+        )
+        assert "創業昭和30年の老舗旅館" in prompt
+
+    def test_highlights_appear_in_prompt(self):
+        generator = CreativeGenerator()
+        prompt = generator._create_lp_generation_prompt(
+            plan=_make_plan(),
+            hotel_detail={"story": "", "highlights": ["源泉かけ流し", "地産地消料理"], "surrounding": {}, "access": ""},
+        )
+        assert "源泉かけ流し" in prompt
+        assert "地産地消料理" in prompt
+
+    def test_surrounding_description_appears_in_prompt(self):
+        generator = CreativeGenerator()
+        prompt = generator._create_lp_generation_prompt(
+            plan=_make_plan(),
+            hotel_detail={
+                "story": "",
+                "highlights": [],
+                "surrounding": {
+                    "description": "南アルプスの麓のエリア",
+                    "attractions": [],
+                },
+                "access": "",
+            },
+        )
+        assert "南アルプスの麓のエリア" in prompt
+
+    def test_attractions_appear_in_prompt(self):
+        generator = CreativeGenerator()
+        prompt = generator._create_lp_generation_prompt(
+            plan=_make_plan(),
+            hotel_detail={
+                "story": "",
+                "highlights": [],
+                "surrounding": {
+                    "description": "",
+                    "attractions": [{"name": "○○温泉郷", "distance": "徒歩5分"}],
+                },
+                "access": "",
+            },
+        )
+        assert "○○温泉郷" in prompt
+        assert "徒歩5分" in prompt
+
+    def test_access_appears_in_prompt(self):
+        generator = CreativeGenerator()
+        prompt = generator._create_lp_generation_prompt(
+            plan=_make_plan(),
+            hotel_detail={"story": "", "highlights": [], "surrounding": {}, "access": "新宿駅から特急で2時間"},
+        )
+        assert "新宿駅から特急で2時間" in prompt
+
+    def test_empty_hotel_detail_adds_no_section(self):
+        """hotel_detail が空・None の場合、宿情報セクションがプロンプトに含まれない"""
+        generator = CreativeGenerator()
+        for hotel_detail in ({}, None):
+            prompt = generator._create_lp_generation_prompt(
+                plan=_make_plan(),
+                hotel_detail=hotel_detail,
+            )
+            assert "【宿のストーリー" not in prompt
+            assert "【宿のハイライト】" not in prompt

--- a/frontend/src/app/facility/hotels/[hotelId]/info/page.tsx
+++ b/frontend/src/app/facility/hotels/[hotelId]/info/page.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  facilityApi,
+  HotelDetail,
+  HotelDetailAttraction,
+  ApiError,
+} from "@/lib/api";
+import {
+  ArrowLeft,
+  Plus,
+  Trash2,
+  Loader2,
+  Save,
+  CheckCircle,
+  Wand2,
+  TrendingUp,
+} from "lucide-react";
+
+const DEFAULT_DETAIL: HotelDetail = {
+  story: "",
+  highlights: [],
+  surrounding: {
+    description: "",
+    attractions: [],
+  },
+  access: "",
+};
+
+export default function HotelInfoPage() {
+  const params = useParams();
+  const hotelId = Number(params.hotelId);
+
+  const [detail, setDetail] = useState<HotelDetail>(DEFAULT_DETAIL);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [autoFilling, setAutoFilling] = useState(false);
+  const [fillingFromMarket, setFillingFromMarket] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ハイライト入力用
+  const [highlightInput, setHighlightInput] = useState("");
+
+  const loadDetail = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await facilityApi.getHotelDetail(hotelId);
+      setDetail({
+        story: data.story || "",
+        highlights: data.highlights || [],
+        surrounding: {
+          description: data.surrounding?.description || "",
+          attractions: data.surrounding?.attractions || [],
+        },
+        access: data.access || "",
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setDetail(DEFAULT_DETAIL);
+      } else {
+        setError("宿情報の取得に失敗しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [hotelId]);
+
+  useEffect(() => {
+    loadDetail();
+  }, [loadDetail]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await facilityApi.updateHotelDetail(hotelId, detail);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch {
+      setError("保存に失敗しました。もう一度お試しください。");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAutoFill = async () => {
+    setAutoFilling(true);
+    setError(null);
+    try {
+      const result = await facilityApi.autoFillHotelDetail(hotelId);
+      setDetail((prev) => ({
+        ...prev,
+        highlights:
+          result.highlights.length > 0 ? result.highlights : prev.highlights,
+        surrounding: {
+          description:
+            result.surrounding.description || prev.surrounding.description,
+          attractions:
+            result.surrounding.attractions.length > 0
+              ? result.surrounding.attractions
+              : prev.surrounding.attractions,
+        },
+        access: result.access || prev.access,
+      }));
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 400) {
+        setError(
+          "公式サイトのURLが設定されていません。ホテル設定から追加してください。"
+        );
+      } else {
+        setError("公式サイトからの情報取得に失敗しました。");
+      }
+    } finally {
+      setAutoFilling(false);
+    }
+  };
+
+  const handleFillFromMarket = async () => {
+    setFillingFromMarket(true);
+    setError(null);
+    try {
+      const result = await facilityApi.fillSurroundingFromMarket(hotelId);
+      setDetail((prev) => ({
+        ...prev,
+        surrounding: {
+          description:
+            result.surrounding.description || prev.surrounding.description,
+          attractions:
+            result.surrounding.attractions.length > 0
+              ? result.surrounding.attractions
+              : prev.surrounding.attractions,
+        },
+      }));
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 400) {
+        setError(
+          "市場分析データがありません。マーケティングAIの「市場を知る」で先に分析を実行してください。"
+        );
+      } else {
+        setError("市場データからの情報取得に失敗しました。");
+      }
+    } finally {
+      setFillingFromMarket(false);
+    }
+  };
+
+  const addHighlight = () => {
+    const trimmed = highlightInput.trim();
+    if (!trimmed) return;
+    setDetail((prev) => ({
+      ...prev,
+      highlights: [...prev.highlights, trimmed],
+    }));
+    setHighlightInput("");
+  };
+
+  const removeHighlight = (index: number) => {
+    setDetail((prev) => ({
+      ...prev,
+      highlights: prev.highlights.filter((_, i) => i !== index),
+    }));
+  };
+
+  const addAttraction = () => {
+    setDetail((prev) => ({
+      ...prev,
+      surrounding: {
+        ...prev.surrounding,
+        attractions: [
+          ...prev.surrounding.attractions,
+          { name: "", distance: "" },
+        ],
+      },
+    }));
+  };
+
+  const updateAttraction = (
+    index: number,
+    field: keyof HotelDetailAttraction,
+    value: string
+  ) => {
+    setDetail((prev) => {
+      const updated = prev.surrounding.attractions.map((a, i) =>
+        i === index ? { ...a, [field]: value } : a
+      );
+      return {
+        ...prev,
+        surrounding: { ...prev.surrounding, attractions: updated },
+      };
+    });
+  };
+
+  const removeAttraction = (index: number) => {
+    setDetail((prev) => ({
+      ...prev,
+      surrounding: {
+        ...prev.surrounding,
+        attractions: prev.surrounding.attractions.filter((_, i) => i !== index),
+      },
+    }));
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-teal-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      {/* ヘッダー */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/facility/hotels"
+            className="p-2 text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">宿の情報</h1>
+            <p className="text-sm text-gray-500 mt-0.5">
+              LP生成に使用する宿のストーリーや周辺情報を入力してください
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleAutoFill}
+          disabled={autoFilling || saving}
+          className="inline-flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium text-purple-700 bg-purple-50 hover:bg-purple-100 border border-purple-200 rounded-md disabled:opacity-60"
+        >
+          {autoFilling ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Wand2 className="h-4 w-4" />
+          )}
+          公式サイトから自動入力
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {/* 宿のストーリー */}
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-base font-semibold text-gray-900 mb-1">
+            宿のストーリー・こだわり
+          </h2>
+          <p className="text-xs text-gray-500 mb-3">
+            創業の歴史や宿のこだわりを自由に記述してください。LP の導入文として使用されます。
+          </p>
+          <textarea
+            value={detail.story}
+            onChange={(e) =>
+              setDetail((prev) => ({ ...prev, story: e.target.value }))
+            }
+            rows={5}
+            placeholder="例）創業昭和30年。山の麓に佇む老舗旅館として、代々地元の食材と天然温泉にこだわり続けてきました..."
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
+          />
+        </div>
+
+        {/* ハイライト */}
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-base font-semibold text-gray-900 mb-1">
+            宿のハイライト
+          </h2>
+          <p className="text-xs text-gray-500 mb-3">
+            宿の強みや特徴を短いフレーズで入力してください（例：源泉かけ流し、地産地消料理）
+          </p>
+          {/* 既存タグ */}
+          <div className="flex flex-wrap gap-2 mb-3">
+            {detail.highlights.map((h, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 px-3 py-1 bg-teal-50 text-teal-800 text-sm rounded-full border border-teal-200"
+              >
+                {h}
+                <button
+                  onClick={() => removeHighlight(i)}
+                  className="ml-1 text-teal-500 hover:text-teal-700"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+          {/* 入力欄 */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={highlightInput}
+              onChange={(e) => setHighlightInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addHighlight();
+                }
+              }}
+              placeholder="ハイライトを入力して Enter または追加ボタン"
+              className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            />
+            <button
+              onClick={addHighlight}
+              className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 rounded-md"
+            >
+              <Plus className="h-4 w-4" />
+              追加
+            </button>
+          </div>
+        </div>
+
+        {/* 周辺情報 */}
+        <div className="bg-white rounded-lg shadow p-6">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-base font-semibold text-gray-900">
+              周辺観光情報
+            </h2>
+            <button
+              onClick={handleFillFromMarket}
+              disabled={fillingFromMarket || saving}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-purple-700 bg-purple-50 hover:bg-purple-100 border border-purple-200 rounded-md disabled:opacity-60"
+            >
+              {fillingFromMarket ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <TrendingUp className="h-3 w-3" />
+              )}
+              市場データから補完
+            </button>
+          </div>
+          <p className="text-xs text-gray-500 mb-4">
+            周辺エリアの説明と近隣の観光スポットを入力してください。マーケティングAIで市場分析済みの場合は「市場データから補完」が利用できます。
+          </p>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              エリア説明
+            </label>
+            <textarea
+              value={detail.surrounding.description}
+              onChange={(e) =>
+                setDetail((prev) => ({
+                  ...prev,
+                  surrounding: {
+                    ...prev.surrounding,
+                    description: e.target.value,
+                  },
+                }))
+              }
+              rows={3}
+              placeholder="例）南アルプスの麓に位置し、豊かな自然に囲まれた静かなエリアです..."
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
+            />
+          </div>
+
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            観光スポット
+          </label>
+          <div className="space-y-2">
+            {detail.surrounding.attractions.map((attraction, i) => (
+              <div key={i} className="flex gap-2 items-center">
+                <input
+                  type="text"
+                  value={attraction.name}
+                  onChange={(e) => updateAttraction(i, "name", e.target.value)}
+                  placeholder="スポット名（例：○○温泉郷）"
+                  className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                />
+                <input
+                  type="text"
+                  value={attraction.distance}
+                  onChange={(e) =>
+                    updateAttraction(i, "distance", e.target.value)
+                  }
+                  placeholder="距離（例：徒歩5分）"
+                  className="w-36 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                />
+                <button
+                  onClick={() => removeAttraction(i)}
+                  className="p-2 text-gray-400 hover:text-red-500 rounded-md"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={addAttraction}
+            className="mt-3 inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-teal-700 bg-teal-50 hover:bg-teal-100 border border-teal-200 rounded-md"
+          >
+            <Plus className="h-4 w-4" />
+            スポットを追加
+          </button>
+        </div>
+
+        {/* アクセス */}
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-base font-semibold text-gray-900 mb-1">
+            アクセス
+          </h2>
+          <p className="text-xs text-gray-500 mb-3">
+            最寄り駅からの経路や送迎情報などを記述してください
+          </p>
+          <textarea
+            value={detail.access}
+            onChange={(e) =>
+              setDetail((prev) => ({ ...prev, access: e.target.value }))
+            }
+            rows={3}
+            placeholder="例）新宿駅から特急あずさで2時間。無料送迎あり（要予約）。お車の場合は中央自動車道○○ICから約15分..."
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
+          />
+        </div>
+
+        {/* 下部保存ボタン */}
+        <div className="flex justify-end pb-8">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex items-center gap-2 px-6 py-2.5 text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 rounded-md disabled:opacity-60"
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : saved ? (
+              <CheckCircle className="h-4 w-4" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            {saved ? "保存しました" : "保存する"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/facility/hotels/page.tsx
+++ b/frontend/src/app/facility/hotels/page.tsx
@@ -15,6 +15,7 @@ import {
   Globe,
   BrainCircuit,
   ImageIcon,
+  BookOpen,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -163,6 +164,17 @@ export default function FacilityHotelsPage() {
                       >
                         <ImageIcon className="h-4 w-4 mr-1" />
                         画像を管理
+                      </Link>
+                    )}
+                    {/* 宿情報入力へのリンク */}
+                    {(hotel.role === "owner" || hotel.role === "editor") && (
+                      <Link
+                        href={`/facility/hotels/${hotel.id}/info`}
+                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                        title="宿のストーリーや周辺情報を管理"
+                      >
+                        <BookOpen className="h-4 w-4 mr-1" />
+                        宿の情報
                       </Link>
                     )}
                     {/* マーケティングAIへのリンク */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,6 +71,31 @@ export interface FacilityImageItem {
   order: number;
 }
 
+// 宿・周辺情報
+export interface HotelDetailAttraction {
+  name: string;
+  distance: string;
+}
+
+export interface HotelDetailSurrounding {
+  description: string;
+  attractions: HotelDetailAttraction[];
+}
+
+export interface HotelDetail {
+  story: string;
+  highlights: string[];
+  surrounding: HotelDetailSurrounding;
+  access: string;
+}
+
+export interface HotelDetailUpdateRequest {
+  story?: string;
+  highlights?: string[];
+  surrounding?: HotelDetailSurrounding;
+  access?: string;
+}
+
 export interface HotelCreateRequest {
   name: string;
   address: string;
@@ -684,6 +709,55 @@ export const facilityApi = {
         method: "PUT",
         body: JSON.stringify(assets),
       },
+      "facility"
+    );
+  },
+
+  /**
+   * 宿・周辺情報を取得
+   */
+  async getHotelDetail(hotelId: number): Promise<HotelDetail> {
+    return apiRequest<HotelDetail>(
+      `/facility/hotels/${hotelId}/detail`,
+      {},
+      "facility"
+    );
+  },
+
+  /**
+   * 宿・周辺情報を更新
+   */
+  async updateHotelDetail(hotelId: number, data: HotelDetailUpdateRequest): Promise<HotelDetail> {
+    return apiRequest<HotelDetail>(
+      `/facility/hotels/${hotelId}/detail`,
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+      "facility"
+    );
+  },
+
+  /**
+   * 公式サイトから宿情報を自動取得
+   */
+  async autoFillHotelDetail(hotelId: number): Promise<HotelDetail> {
+    return apiRequest<HotelDetail>(
+      `/facility/hotels/${hotelId}/detail/auto-fill`,
+      { method: "POST" },
+      "facility"
+    );
+  },
+
+  /**
+   * 市場分析データ（地域トレンド）から周辺観光情報を生成
+   */
+  async fillSurroundingFromMarket(
+    hotelId: number
+  ): Promise<{ surrounding: HotelDetailSurrounding }> {
+    return apiRequest<{ surrounding: HotelDetailSurrounding }>(
+      `/facility/hotels/${hotelId}/detail/fill-surrounding-from-market`,
+      { method: "POST" },
       "facility"
     );
   },


### PR DESCRIPTION
## 概要

- `hotel_detail` フィールド（story / highlights / surrounding / access）を Hotel モデルに追加し、LP 生成プロンプトに組み込み
- 宿の情報管理画面（`/facility/hotels/[hotelId]/info/`）を新規追加
- 公式サイトから自動入力・市場データから周辺観光情報を補完する AI 機能を追加

## 変更内容

### Backend
- **モデル**: `Hotel.hotel_detail`（JSON）を追加、マイグレーション `007_add_hotel_detail.py`
- **API** `facility_hotels.py`:
  - `GET/PUT /{hotel_id}/detail` — hotel_detail の取得・更新
  - `POST /{hotel_id}/detail/auto-fill` — 公式サイトをスクレイプし Gemini で highlights / surrounding / access を構造化生成
  - `POST /{hotel_id}/detail/fill-surrounding-from-market` — 市場分析の `regional_trends` から周辺観光情報を抽出
- **サービス** `hotel_scrape_service.py`: httpx + stdlib HTMLParser でテキスト抽出、LLM で JSON 生成
- **LP 生成** `creative_generator.py`: `_create_lp_generation_prompt()` に hotel_detail セクションを追加

### Frontend
- **新規ページ** `/facility/hotels/[hotelId]/info/page.tsx`
  - ストーリー・ハイライト・周辺観光情報・アクセスの入力フォーム
  - 「公式サイトから自動入力」ボタン（全フィールド対象）
  - 「市場データから補完」ボタン（周辺観光情報セクションに配置、市場分析済みの場合のみ有効）
  - 自動入力はデータが空のフィールドのみ上書きするマージ戦略
- **api.ts**: `getHotelDetail` / `updateHotelDetail` / `autoFillHotelDetail` / `fillSurroundingFromMarket` を追加
- **施設一覧**: 「宿の情報」ボタンを追加

## スクショ
<img width="879" height="1144" alt="image" src="https://github.com/user-attachments/assets/b3f56b07-dfdb-491e-99ce-7f3da8615362" />
<img width="791" height="269" alt="image" src="https://github.com/user-attachments/assets/6431e463-e762-4d07-a582-482798bf1f23" />

## テスト

- [x] マイグレーション実行後、`hotels.hotel_detail` カラムが存在することを確認
- [x] `/facility/hotels/[hotelId]/info` にアクセスし、各フォームに入力・保存できることを確認
- [x] `hotel.website` 設定済みの施設で「公式サイトから自動入力」が動作することを確認
- [x] `hotel.website` 未設定の場合にエラーメッセージが表示されることを確認
- [x] マーケティング AI で市場分析済みの施設で「市場データから補完」が動作することを確認
- [x] 市場分析未実施の場合にエラーメッセージが表示されることを確認
- [x] LP 生成後、hotel_detail の内容がコンテンツに反映されていることを確認


## 備考
### フィールド別の役割
「宿の情報」画面（`/facility/hotels/[hotelId]/info/`）で入力した `hotel_detail` は、LP生成時にAIプロンプトへ埋め込まれ、HTMLコンテンツとして生成される。ハードコードではなくAIが文脈として解釈するため、入力が充実するほどLPクオリティが向上する想定。

| フィールド | DB列 | LPでの役割 |
|---|---|---|
| ストーリー・こだわり | `hotel_detail.story` | 導入セクション・コンセプト文 |
| ハイライト | `hotel_detail.highlights` | 特徴訴求セクションの箇条書き |
| 周辺観光 / エリア説明 | `hotel_detail.surrounding.description` | 「周辺の魅力」セクションの説明文 |
| 周辺観光 / 観光スポット | `hotel_detail.surrounding.attractions` | スポット名と距離の一覧 |
| アクセス | `hotel_detail.access` | アクセスセクションのテキスト |