### PR TITLE
[Issue #2] LP調整UI・修正履歴プレビュー機能

### DIFF
--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -15,8 +15,10 @@ from app.core.config import settings
 from app.models import MarketingPlan, CreativeAsset, AnalysisSession, FacilityAdminHotel, Hotel
 from app.schemas.creative import (
     CreativeGenerationRequest,
-    CreativeAssetResponse
+    CreativeAssetResponse,
+    LpAdjustRequest,
 )
+from datetime import datetime, timezone
 from app.services.creative_generator import CreativeGenerator
 from app.auth.dependencies import require_hotel_access, require_hotel_editor
 
@@ -507,6 +509,101 @@ async def save_lp_to_file(
     
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"LP保存エラー: {str(e)}")
+
+
+@router.post("/hotels/{hotel_id}/assets/{asset_id}/adjust-lp", response_model=CreativeAssetResponse)
+async def adjust_lp(
+    hotel_id: int,
+    asset_id: int,
+    request: LpAdjustRequest,
+    permission: FacilityAdminHotel = Depends(require_hotel_access),
+    session: Session = Depends(get_session)
+):
+    """
+    既存LPに自然言語で修正指示を出し、LLMが差分更新する（Issue #2）
+
+    - Stage 1: Gemini Flash で変更箇所を特定・最小コンテキスト抽出
+    - Stage 2: Gemini Pro で修正を適用
+    - 画像パスが壊れた場合は元のHTMLに戻す
+    - 修正履歴を lp_revision_history に追記（DB上限10件）
+    """
+    # 権限チェック
+    analysis_statement = select(AnalysisSession).where(AnalysisSession.hotel_id == hotel_id)
+    analysis_session = session.exec(analysis_statement).first()
+    if not analysis_session:
+        raise HTTPException(status_code=404, detail="分析セッションが見つかりません")
+
+    asset = session.get(CreativeAsset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="クリエイティブアセットが見つかりません")
+
+    marketing_plan = session.get(MarketingPlan, asset.marketing_plan_id)
+    if not marketing_plan or marketing_plan.analysis_session_id != analysis_session.id:
+        raise HTTPException(status_code=403, detail="このアセットへのアクセス権限がありません")
+
+    if not asset.lp_source_code:
+        raise HTTPException(status_code=400, detail="LPソースコードがありません。先にLPを生成してください。")
+
+    instruction = request.instruction.strip()
+    if not instruction:
+        raise HTTPException(status_code=400, detail="修正指示を入力してください")
+
+    try:
+        generator = CreativeGenerator()
+
+        # Stage1: Flash（高速・安価）
+        flash_client = get_llm_client(model_name="gemini-2.5-flash-lite")
+        # Stage2: Pro（高精度）
+        pro_client = get_llm_client(model_name="gemini-3.1-pro-preview")
+
+        updated_html, summary = await generator.adjust_landing_page(
+            lp_source_code=asset.lp_source_code,
+            instruction=instruction,
+            lp_image_urls=asset.lp_image_urls or {},
+            flash_client=flash_client,
+            pro_client=pro_client,
+        )
+
+        if updated_html == asset.lp_source_code and summary.startswith("調整失敗"):
+            raise HTTPException(status_code=500, detail=f"LP調整に失敗しました: {summary}")
+
+        # 修正履歴を追記（上限10件）
+        history: list = list(asset.lp_revision_history or [])
+        history.append({
+            "revision_id": str(uuid.uuid4()),
+            "instruction": instruction,
+            "summary": summary,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "lp_source_code": asset.lp_source_code,  # 修正前スナップショット
+        })
+        if len(history) > 10:
+            history = history[-10:]
+
+        asset.lp_source_code = updated_html
+        asset.lp_revision_history = history
+        flag_modified(asset, "lp_revision_history")
+
+        # 静的ファイルも更新
+        image_urls = {
+            k: v for k, v in (asset.lp_image_urls or {}).items()
+            if isinstance(v, str) and v.startswith("/static/")
+        }
+        preview_url = generator.save_lp_to_file(
+            lp_source_code=updated_html,
+            hotel_id=hotel_id,
+            asset_id=asset_id,
+            image_urls=image_urls or None,
+        )
+        asset.lp_preview_url = preview_url
+
+        session.commit()
+        session.refresh(asset)
+        return asset
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"LP調整エラー: {str(e)}")
 
 
 @router.delete("/hotels/{hotel_id}/assets/{asset_id}")

--- a/backend/app/api/creative.py
+++ b/backend/app/api/creative.py
@@ -370,9 +370,22 @@ async def generate_creative_assets_authenticated(
             "ota_text_prompt": ota_text_prompt
         }
         
+        # LP初版エントリを生成
+        initial_revision_entry = None
+        if lp_code:
+            initial_revision_entry = {
+                "revision_id": str(uuid.uuid4()),
+                "instruction": "初版生成",
+                "summary": "初版",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "lp_source_code": lp_code,
+            }
+
         if existing_asset:
             if lp_code:
                 existing_asset.lp_source_code = lp_code
+                existing_asset.lp_revision_history = [initial_revision_entry]
+                flag_modified(existing_asset, "lp_revision_history")
             if lp_image_urls:
                 existing_asset.lp_image_urls = lp_image_urls
             if ad_image_urls:
@@ -391,13 +404,14 @@ async def generate_creative_assets_authenticated(
                 ad_image_urls=ad_image_urls,
                 ad_copy=ad_copy,
                 ota_text=ota_text,
-                generation_prompts=generation_prompts
+                generation_prompts=generation_prompts,
+                lp_revision_history=[initial_revision_entry] if initial_revision_entry else [],
             )
             session.add(creative_asset)
-        
+
         session.commit()
         session.refresh(creative_asset)
-        
+
         # LPが生成されている場合はファイルとして保存
         if lp_code and creative_asset.id:
             # LP用画像のみを抽出してプレビュー用に渡す
@@ -574,7 +588,7 @@ async def adjust_lp(
             "instruction": instruction,
             "summary": summary,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "lp_source_code": asset.lp_source_code,  # 修正前スナップショット
+            "lp_source_code": updated_html,  # 修正後スナップショット
         })
         if len(history) > 10:
             history = history[-10:]
@@ -742,10 +756,23 @@ async def generate_creative_assets(
             "ad_copy_warnings": ad_copy_warnings
         }
         
+        # LP初版エントリを生成
+        initial_revision_entry_2 = None
+        if lp_code:
+            initial_revision_entry_2 = {
+                "revision_id": str(uuid.uuid4()),
+                "instruction": "初版生成",
+                "summary": "初版",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "lp_source_code": lp_code,
+            }
+
         if existing_asset:
             # 既存アセットを更新
             if lp_code:
                 existing_asset.lp_source_code = lp_code
+                existing_asset.lp_revision_history = [initial_revision_entry_2]
+                flag_modified(existing_asset, "lp_revision_history")
             if image_prompts:
                 existing_asset.ad_image_urls = image_prompts
             if ad_copy:
@@ -759,7 +786,8 @@ async def generate_creative_assets(
                 lp_source_code=lp_code,
                 ad_image_urls=image_prompts,
                 ad_copy=ad_copy,
-                generation_prompts=generation_prompts
+                generation_prompts=generation_prompts,
+                lp_revision_history=[initial_revision_entry_2] if initial_revision_entry_2 else [],
             )
             session.add(creative_asset)
         

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -303,7 +303,10 @@ class CreativeAsset(SQLModel, table=True):
     
     # 生成メタデータ
     generation_prompts: dict = Field(default_factory=dict, sa_column=Column(JSON))  # 使用したプロンプト
-    
+
+    # LP修正履歴（最大10件、古い順に削除）
+    lp_revision_history: list = Field(default_factory=list, sa_column=Column(JSON))
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     

--- a/backend/app/schemas/creative.py
+++ b/backend/app/schemas/creative.py
@@ -11,6 +11,20 @@ class CreativeGenerationRequest(BaseModel):
     generate_ad_copy: bool = True  # 広告コピーを生成するか
 
 
+class LpRevisionEntry(BaseModel):
+    """LP修正履歴エントリ"""
+    revision_id: str
+    instruction: str
+    summary: str
+    timestamp: str
+    lp_source_code: str
+
+
+class LpAdjustRequest(BaseModel):
+    """LP調整リクエスト"""
+    instruction: str
+
+
 class CreativeAssetResponse(BaseModel):
     """クリエイティブアセットレスポンス"""
     id: int
@@ -22,8 +36,9 @@ class CreativeAssetResponse(BaseModel):
     ad_copy: Dict
     ota_text: Dict = {}  # OTAテキスト（じゃらん、楽天トラベル向け）
     generation_prompts: Dict
+    lp_revision_history: List = []  # LP修正履歴（最大10件）
     created_at: datetime
-    
+
     class Config:
         from_attributes = True
 

--- a/backend/app/services/creative_generator.py
+++ b/backend/app/services/creative_generator.py
@@ -2,7 +2,8 @@ import json
 import re
 import os
 import uuid
-from typing import Dict, Optional, Tuple
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
 from app.models import MarketingPlan
 from app.core.language import get_language_instruction, get_language_name, is_japanese
 
@@ -1413,3 +1414,172 @@ The image should make viewers want to book immediately.""",
                     "features": ["特別な体験", "くつろぎの空間", "おもてなし"]
                 }
             }
+
+    # -------------------------------------------------------------------------
+    # LP調整機能（Issue #2）
+    # -------------------------------------------------------------------------
+
+    def _validate_image_paths(self, html: str, lp_image_urls: Dict) -> bool:
+        """LP HTML内の画像パスが壊れていないか確認する"""
+        for path in lp_image_urls.values():
+            if not isinstance(path, str):
+                continue
+            filename = os.path.basename(path)
+            if filename and filename not in html:
+                print(f"[LP調整] 画像パス消失を検出: {filename}")
+                return False
+        return True
+
+    async def adjust_landing_page(
+        self,
+        lp_source_code: str,
+        instruction: str,
+        lp_image_urls: Dict,
+        flash_client,
+        pro_client,
+    ) -> Tuple[str, str]:
+        """
+        2段階LLMでLPを差分更新する
+
+        Stage 1 (Flash): 変更箇所を特定し、最小限のHTMLコンテキストを抽出
+        Stage 2 (Pro):   抽出コンテキストのみを渡して修正を適用
+
+        Args:
+            lp_source_code: 現在のLP HTML
+            instruction:    ユーザーの修正指示（自然言語）
+            lp_image_urls:  画像パス辞書（破壊チェック用）
+            flash_client:   Stage 1用 LLMClient（軽量モデル）
+            pro_client:     Stage 2用 LLMClient（高精度モデル）
+
+        Returns:
+            (updated_html, summary) のタプル
+            更新失敗時は元の lp_source_code をそのまま返す
+        """
+        # ------------------------------------------------------------------
+        # Stage 1: Flash で変更箇所を特定・コンテキスト抽出
+        # ------------------------------------------------------------------
+        stage1_system = (
+            "あなたはHTMLの差分修正を支援するアシスタントです。"
+            "ユーザーの指示に従い、修正が必要なHTML断片のみを抽出してください。"
+            "必ずJSON形式で出力してください。マークダウンのコードブロックは不要です。"
+        )
+        stage1_prompt = f"""以下のLP HTMLに対して、ユーザーの修正指示を分析してください。
+
+【修正指示】
+{instruction}
+
+【LP HTML（先頭3000文字）】
+{lp_source_code[:3000]}
+
+【LP HTML（末尾2000文字）】
+{lp_source_code[-2000:] if len(lp_source_code) > 5000 else ""}
+
+以下のJSON形式で回答してください:
+{{
+  "summary": "修正内容の要約（20文字以内）",
+  "target_description": "変更対象要素の説明",
+  "extracted_context": "変更対象のHTML断片（変更前の実際のHTMLコードを抜粋）",
+  "modification_instruction": "Stage2への詳細な修正指示"
+}}"""
+
+        try:
+            stage1_raw = await flash_client.generate_structured_output(
+                user_prompt=stage1_prompt,
+                system_prompt=stage1_system,
+                max_tokens=2048,
+            )
+        except Exception as e:
+            print(f"[LP調整] Stage1エラー: {e}")
+            return lp_source_code, "調整失敗"
+
+        # Stage1のJSON解析
+        try:
+            json_match = re.search(r'\{.*\}', stage1_raw, re.DOTALL)
+            stage1_result = json.loads(json_match.group() if json_match else stage1_raw)
+        except Exception:
+            stage1_result = {
+                "summary": instruction[:20],
+                "extracted_context": lp_source_code[:4000],
+                "modification_instruction": instruction,
+            }
+
+        summary = stage1_result.get("summary", instruction[:20])
+        if not isinstance(summary, str):
+            summary = instruction[:20]
+
+        extracted_context = stage1_result.get("extracted_context", lp_source_code[:4000])
+        if not isinstance(extracted_context, str):
+            extracted_context = lp_source_code[:4000]
+
+        modification_instruction = stage1_result.get("modification_instruction", instruction)
+        if not isinstance(modification_instruction, str):
+            modification_instruction = instruction
+
+        # ------------------------------------------------------------------
+        # Stage 2: Pro でHTML断片を修正
+        # ------------------------------------------------------------------
+        stage2_system = (
+            "あなたは宿泊施設LPのHTMLを修正する専門エンジニアです。"
+            "指示された箇所のみを修正し、修正後のHTML断片のみを出力してください。"
+            "画像のsrc属性は絶対に変更しないでください。"
+            "コードブロック（```）で囲まずに、純粋なHTMLのみを返してください。"
+        )
+        stage2_prompt = f"""以下のHTML断片を修正してください。
+
+【修正指示】
+{modification_instruction}
+
+【元のHTML断片】
+{extracted_context}
+
+修正後のHTML断片のみを出力してください（説明文不要）。"""
+
+        try:
+            modified_fragment = await pro_client.generate_text(
+                user_prompt=stage2_prompt,
+                system_prompt=stage2_system,
+                max_tokens=8000,
+            )
+        except Exception as e:
+            print(f"[LP調整] Stage2エラー: {e}")
+            return lp_source_code, "調整失敗"
+
+        # コードブロックを除去
+        modified_fragment = self._extract_code_from_response(modified_fragment)
+
+        # ------------------------------------------------------------------
+        # 元のHTMLへの反映（断片置換）
+        # ------------------------------------------------------------------
+        if extracted_context and extracted_context in lp_source_code:
+            updated_html = lp_source_code.replace(extracted_context, modified_fragment, 1)
+        else:
+            # 断片が見つからない場合はStage2を全HTML適用にフォールバック
+            print("[LP調整] 断片置換できなかったため全文修正にフォールバック")
+            fallback_prompt = f"""以下のLP HTML全体に対して修正を適用してください。
+
+【修正指示】
+{instruction}
+
+【LP HTML】
+{lp_source_code}
+
+修正後のHTML全体を出力してください。画像のsrc属性は変更しないでください。"""
+            try:
+                updated_html_raw = await pro_client.generate_text(
+                    user_prompt=fallback_prompt,
+                    system_prompt=stage2_system,
+                    max_tokens=16000,
+                )
+                updated_html = self._extract_code_from_response(updated_html_raw)
+            except Exception as e:
+                print(f"[LP調整] フォールバックエラー: {e}")
+                return lp_source_code, "調整失敗"
+
+        # ------------------------------------------------------------------
+        # 画像パス検証
+        # ------------------------------------------------------------------
+        if lp_image_urls and not self._validate_image_paths(updated_html, lp_image_urls):
+            print("[LP調整] 画像パスが破壊されたため修正前に戻します")
+            return lp_source_code, "調整失敗（画像パス破壊）"
+
+        return updated_html, summary

--- a/backend/migrations/versions/008_add_lp_revision_history.py
+++ b/backend/migrations/versions/008_add_lp_revision_history.py
@@ -1,0 +1,48 @@
+"""Add lp_revision_history column to creative_assets
+
+Revision ID: 008_add_lp_revision_history
+Revises: 007_add_hotel_detail
+Create Date: 2026-03-10
+
+LP調整機能のための修正履歴カラムを creative_assets テーブルに追加
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '008_add_lp_revision_history'
+down_revision: Union[str, None] = '007_add_hotel_detail'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """creative_assetsテーブルに lp_revision_history カラムを追加（既存の場合はスキップ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'creative_assets' AND column_name = 'lp_revision_history'"
+        )
+    ).scalar()
+    if result is None:
+        op.add_column(
+            'creative_assets',
+            sa.Column('lp_revision_history', postgresql.JSONB(), nullable=True, server_default='[]')
+        )
+
+
+def downgrade() -> None:
+    """lp_revision_history カラムを削除（存在する場合のみ）"""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'creative_assets' AND column_name = 'lp_revision_history'"
+        )
+    ).scalar()
+    if result is not None:
+        op.drop_column('creative_assets', 'lp_revision_history')

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -70,6 +70,9 @@ export default function ContentPage() {
   const [previewingRevision, setPreviewingRevision] = useState<LpRevisionEntry | null>(null);
   const blobUrlRef = useRef<string | null>(null);
 
+  // HTML表示エリアに表示するリビジョン（nullなら最新）
+  const [displayedHtmlRevision, setDisplayedHtmlRevision] = useState<LpRevisionEntry | null>(null);
+
   // SNS投稿ジェネレーター関連のstate
   const [snsPlatform, setSnsPlatform] = useState<string>("");
   const [snsPostType, setSnsPostType] = useState<string>("");
@@ -714,20 +717,29 @@ export default function ContentPage() {
                           </div>
                           <div className="space-y-2">
                             {[...currentAsset.lp_revision_history].reverse().map((entry) => (
-                              <div key={entry.revision_id} className="flex items-start justify-between gap-2 bg-white/5 rounded-lg p-2.5 border border-white/10">
-                                <div className="flex-1 min-w-0">
+                              <div key={entry.revision_id} className={`bg-white/5 rounded-lg p-2.5 border transition-all ${displayedHtmlRevision?.revision_id === entry.revision_id ? "border-amber-500/50 bg-amber-500/10" : "border-white/10"}`}>
+                                <div className="mb-1.5">
                                   <p className="text-xs text-white font-medium truncate">{entry.summary}</p>
                                   <p className="text-xs text-slate-500 mt-0.5">
                                     {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
                                   </p>
                                 </div>
-                                <button
-                                  onClick={() => handlePreviewRevision(entry)}
-                                  className="flex-shrink-0 flex items-center gap-1 px-2 py-1 bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-all text-xs"
-                                >
-                                  <Eye className="w-3 h-3" />
-                                  表示
-                                </button>
+                                <div className="flex gap-1.5">
+                                  <button
+                                    onClick={() => handlePreviewRevision(entry)}
+                                    className="flex-1 flex items-center justify-center gap-1 px-2 py-1 bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-all text-xs"
+                                  >
+                                    <Eye className="w-3 h-3" />
+                                    表示
+                                  </button>
+                                  <button
+                                    onClick={() => setDisplayedHtmlRevision(displayedHtmlRevision?.revision_id === entry.revision_id ? null : entry)}
+                                    className={`flex-1 flex items-center justify-center gap-1 px-2 py-1 rounded transition-all text-xs ${displayedHtmlRevision?.revision_id === entry.revision_id ? "bg-amber-500/30 text-amber-300" : "bg-white/10 text-slate-300 hover:bg-white/20"}`}
+                                  >
+                                    <FileCode className="w-3 h-3" />
+                                    HTML表示
+                                  </button>
+                                </div>
                               </div>
                             ))}
                           </div>
@@ -736,9 +748,23 @@ export default function ContentPage() {
                     </div>
                   ) : null}
 
-                  <div className="bg-white/5 rounded-lg p-4 max-h-64 overflow-auto">
+                  {displayedHtmlRevision && (
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="flex items-center gap-1.5 text-xs text-amber-400">
+                        <History className="w-3.5 h-3.5" />
+                        過去バージョンのHTMLを表示中：{displayedHtmlRevision.summary}
+                      </span>
+                      <button
+                        onClick={() => setDisplayedHtmlRevision(null)}
+                        className="text-xs text-slate-400 hover:text-white transition-colors"
+                      >
+                        最新に戻す
+                      </button>
+                    </div>
+                  )}
+                  <div className={`bg-white/5 rounded-lg p-4 max-h-64 overflow-auto ${displayedHtmlRevision ? "border border-amber-500/30" : ""}`}>
                     <pre className="text-slate-300 text-xs whitespace-pre-wrap">
-                      {currentAsset.lp_source_code}
+                      {displayedHtmlRevision ? displayedHtmlRevision.lp_source_code : currentAsset.lp_source_code}
                     </pre>
                   </div>
                 </div>

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Instagram, Loader2, Wand2, FileCode, Image, MessageSquare, CheckCircle, AlertCircle, Eye, ExternalLink, X, Link2, Upload, Send, History } from "lucide-react";
 import { useHotel } from "@/lib/hotel-context";
-import { marketingApi, facilityApi, MarketingPlan, CreativeAsset, HotelResponse, SNSPostResponse } from "@/lib/api";
+import { marketingApi, facilityApi, MarketingPlan, CreativeAsset, HotelResponse, SNSPostResponse, LpRevisionEntry } from "@/lib/api";
 import Link from "next/link";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -65,6 +65,10 @@ export default function ContentPage() {
   const [lpAdjustInstruction, setLpAdjustInstruction] = useState<string>("");
   const [adjustingLp, setAdjustingLp] = useState(false);
   const [lpAdjustError, setLpAdjustError] = useState<string>("");
+
+  // 過去リビジョンのプレビュー関連
+  const [previewingRevision, setPreviewingRevision] = useState<LpRevisionEntry | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
 
   // SNS投稿ジェネレーター関連のstate
   const [snsPlatform, setSnsPlatform] = useState<string>("");
@@ -327,6 +331,26 @@ export default function ContentPage() {
     }
   };
 
+  // 過去リビジョンをプレビューで表示
+  const handlePreviewRevision = (entry: LpRevisionEntry) => {
+    // 前のblobUrlを破棄
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+    }
+    const blob = new Blob([entry.lp_source_code], { type: "text/html" });
+    const blobUrl = URL.createObjectURL(blob);
+    blobUrlRef.current = blobUrl;
+    setPreviewingRevision(entry);
+    setPreviewUrl(blobUrl);
+    setShowPreviewModal(true);
+  };
+
+  // 現在のLPをプレビュー（リビジョン表示モードを解除）
+  const handlePreviewCurrent = async () => {
+    setPreviewingRevision(null);
+    await handleOpenPreview();
+  };
+
   const currentAsset = assets[0];
 
   return (
@@ -576,111 +600,142 @@ export default function ContentPage() {
                     </div>
                   </div>
                   
-                  {/* LP用画像セクション */}
-                  {currentAsset.lp_image_urls && Object.keys(currentAsset.lp_image_urls).length > 0 && (
-                    <div className="mb-4">
-                      <p className="text-sm text-slate-400 mb-3">LP用画像（クリックで差し替え可能）</p>
-                      <div className="grid grid-cols-3 gap-3">
-                        {Object.entries(currentAsset.lp_image_urls).map(([key, value]) => {
-                          const imageValue = value as Record<string, unknown> | string | null;
-                          const isError = typeof imageValue === "object" && imageValue !== null && "error" in imageValue;
-                          const isValidType = ["hero", "feature", "feature1", "feature2", "feature3", "surrounding", "ambiance"].includes(key);
-                          const isUploading = uploadingImage === key;
-                          
-                          return (
-                            <div key={key} className="relative group">
-                              <p className="text-xs text-slate-500 mb-1 flex items-center gap-1">
-                                {key}
-                                {isValidType && (
-                                  <span className="text-slate-600">（差し替え可）</span>
-                                )}
-                              </p>
-                              
-                              {/* 隠しファイル入力 */}
-                              {isValidType && (
-                                <input
-                                  type="file"
-                                  ref={(el) => { fileInputRefs.current[key] = el; }}
-                                  accept="image/jpeg,image/png,image/webp"
-                                  className="hidden"
-                                  onChange={(e) => {
-                                    const file = e.target.files?.[0];
-                                    if (file) {
-                                      // ファイルを選択したらプレビューを表示（即座にアップロードしない）
-                                      const previewUrl = URL.createObjectURL(file);
-                                      setPendingImageUpload({
-                                        imageType: key,
-                                        file,
-                                        previewUrl,
-                                      });
-                                    }
-                                    e.target.value = "";
-                                  }}
-                                />
-                              )}
-                              
-                              {typeof imageValue === "string" && imageValue.startsWith("/static/") ? (
-                                <div 
-                                  className={`relative aspect-video rounded-lg overflow-hidden bg-slate-800 ${isValidType && !isUploading ? 'cursor-pointer' : ''}`}
-                                  onClick={() => isValidType && !isUploading && triggerFileInput(key)}
-                                >
-                                  <img
-                                    src={`${API_BASE_URL}${imageValue}`}
-                                    alt={key}
-                                    className="w-full h-full object-cover"
-                                  />
-                                  {/* アップロードオーバーレイ */}
-                                  {isValidType && !isUploading && (
-                                    <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                                      <div className="text-center">
-                                        <Upload className="w-6 h-6 text-white mx-auto mb-1" />
-                                        <span className="text-white text-xs">画像を差し替え</span>
-                                      </div>
-                                    </div>
+                  {/* LP用画像 + 修正履歴（横並び） */}
+                  {(currentAsset.lp_image_urls && Object.keys(currentAsset.lp_image_urls).length > 0) || (currentAsset.lp_revision_history && currentAsset.lp_revision_history.length > 0) ? (
+                    <div className="flex gap-4 mb-4 items-start">
+                      {/* LP用画像セクション */}
+                      {currentAsset.lp_image_urls && Object.keys(currentAsset.lp_image_urls).length > 0 && (
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-slate-400 mb-3">LP用画像（クリックで差し替え可能）</p>
+                          <div className="grid grid-cols-3 gap-3">
+                            {Object.entries(currentAsset.lp_image_urls).map(([key, value]) => {
+                              const imageValue = value as Record<string, unknown> | string | null;
+                              const isError = typeof imageValue === "object" && imageValue !== null && "error" in imageValue;
+                              const isValidType = ["hero", "feature", "feature1", "feature2", "feature3", "surrounding", "ambiance"].includes(key);
+                              const isUploading = uploadingImage === key;
+
+                              return (
+                                <div key={key} className="relative group">
+                                  <p className="text-xs text-slate-500 mb-1 flex items-center gap-1">
+                                    {key}
+                                    {isValidType && (
+                                      <span className="text-slate-600">（差し替え可）</span>
+                                    )}
+                                  </p>
+
+                                  {/* 隠しファイル入力 */}
+                                  {isValidType && (
+                                    <input
+                                      type="file"
+                                      ref={(el) => { fileInputRefs.current[key] = el; }}
+                                      accept="image/jpeg,image/png,image/webp"
+                                      className="hidden"
+                                      onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) {
+                                          const previewUrl = URL.createObjectURL(file);
+                                          setPendingImageUpload({
+                                            imageType: key,
+                                            file,
+                                            previewUrl,
+                                          });
+                                        }
+                                        e.target.value = "";
+                                      }}
+                                    />
                                   )}
-                                  {/* アップロード中 */}
-                                  {isUploading && (
-                                    <div className="absolute inset-0 bg-black/70 flex items-center justify-center">
-                                      <Loader2 className="w-6 h-6 text-white animate-spin" />
+
+                                  {typeof imageValue === "string" && imageValue.startsWith("/static/") ? (
+                                    <div
+                                      className={`relative aspect-video rounded-lg overflow-hidden bg-slate-800 ${isValidType && !isUploading ? 'cursor-pointer' : ''}`}
+                                      onClick={() => isValidType && !isUploading && triggerFileInput(key)}
+                                    >
+                                      <img
+                                        src={`${API_BASE_URL}${imageValue}`}
+                                        alt={key}
+                                        className="w-full h-full object-cover"
+                                      />
+                                      {isValidType && !isUploading && (
+                                        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                          <div className="text-center">
+                                            <Upload className="w-6 h-6 text-white mx-auto mb-1" />
+                                            <span className="text-white text-xs">画像を差し替え</span>
+                                          </div>
+                                        </div>
+                                      )}
+                                      {isUploading && (
+                                        <div className="absolute inset-0 bg-black/70 flex items-center justify-center">
+                                          <Loader2 className="w-6 h-6 text-white animate-spin" />
+                                        </div>
+                                      )}
                                     </div>
-                                  )}
-                                </div>
-                              ) : isError ? (
-                                <div 
-                                  className={`aspect-video rounded-lg bg-red-500/10 border border-red-500/30 flex items-center justify-center ${isValidType && !isUploading ? 'cursor-pointer hover:bg-red-500/20' : ''}`}
-                                  onClick={() => isValidType && !isUploading && triggerFileInput(key)}
-                                >
-                                  {isUploading ? (
-                                    <Loader2 className="w-6 h-6 text-red-400 animate-spin" />
+                                  ) : isError ? (
+                                    <div
+                                      className={`aspect-video rounded-lg bg-red-500/10 border border-red-500/30 flex items-center justify-center ${isValidType && !isUploading ? 'cursor-pointer hover:bg-red-500/20' : ''}`}
+                                      onClick={() => isValidType && !isUploading && triggerFileInput(key)}
+                                    >
+                                      {isUploading ? (
+                                        <Loader2 className="w-6 h-6 text-red-400 animate-spin" />
+                                      ) : (
+                                        <div className="text-center">
+                                          <Upload className="w-5 h-5 text-red-400 mx-auto mb-1" />
+                                          <span className="text-red-400 text-xs">画像をアップロード</span>
+                                        </div>
+                                      )}
+                                    </div>
                                   ) : (
-                                    <div className="text-center">
-                                      <Upload className="w-5 h-5 text-red-400 mx-auto mb-1" />
-                                      <span className="text-red-400 text-xs">画像をアップロード</span>
+                                    <div
+                                      className={`aspect-video rounded-lg bg-slate-700 flex items-center justify-center ${isValidType && !isUploading ? 'cursor-pointer hover:bg-slate-600' : ''}`}
+                                      onClick={() => isValidType && !isUploading && triggerFileInput(key)}
+                                    >
+                                      {isUploading ? (
+                                        <Loader2 className="w-6 h-6 text-slate-400 animate-spin" />
+                                      ) : (
+                                        <div className="text-center">
+                                          <Upload className="w-5 h-5 text-slate-400 mx-auto mb-1" />
+                                          <span className="text-slate-500 text-xs">画像をアップロード</span>
+                                        </div>
+                                      )}
                                     </div>
                                   )}
                                 </div>
-                              ) : (
-                                <div 
-                                  className={`aspect-video rounded-lg bg-slate-700 flex items-center justify-center ${isValidType && !isUploading ? 'cursor-pointer hover:bg-slate-600' : ''}`}
-                                  onClick={() => isValidType && !isUploading && triggerFileInput(key)}
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* 修正履歴（右側） */}
+                      {currentAsset.lp_revision_history && currentAsset.lp_revision_history.length > 0 && (
+                        <div className="w-64 flex-shrink-0">
+                          <div className="flex items-center gap-2 mb-3">
+                            <History className="w-4 h-4 text-slate-400" />
+                            <span className="text-sm text-slate-400">修正履歴</span>
+                          </div>
+                          <div className="space-y-2">
+                            {[...currentAsset.lp_revision_history].reverse().map((entry) => (
+                              <div key={entry.revision_id} className="flex items-start justify-between gap-2 bg-white/5 rounded-lg p-2.5 border border-white/10">
+                                <div className="flex-1 min-w-0">
+                                  <p className="text-xs text-white font-medium truncate">{entry.summary}</p>
+                                  <p className="text-xs text-slate-500 mt-0.5">
+                                    {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                                  </p>
+                                </div>
+                                <button
+                                  onClick={() => handlePreviewRevision(entry)}
+                                  className="flex-shrink-0 flex items-center gap-1 px-2 py-1 bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-all text-xs"
                                 >
-                                  {isUploading ? (
-                                    <Loader2 className="w-6 h-6 text-slate-400 animate-spin" />
-                                  ) : (
-                                    <div className="text-center">
-                                      <Upload className="w-5 h-5 text-slate-400 mx-auto mb-1" />
-                                      <span className="text-slate-500 text-xs">画像をアップロード</span>
-                                    </div>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
+                                  <Eye className="w-3 h-3" />
+                                  表示
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  )}
-                  
+                  ) : null}
+
                   <div className="bg-white/5 rounded-lg p-4 max-h-64 overflow-auto">
                     <pre className="text-slate-300 text-xs whitespace-pre-wrap">
                       {currentAsset.lp_source_code}
@@ -1418,19 +1473,36 @@ export default function ContentPage() {
               <div className="flex items-center gap-3">
                 <Eye className="w-5 h-5 text-blue-400" />
                 <h3 className="text-lg font-semibold text-white">LPプレビュー</h3>
+                {previewingRevision && (
+                  <span className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-500/20 text-amber-400 rounded-lg text-xs font-medium">
+                    <History className="w-3.5 h-3.5" />
+                    過去バージョン表示中
+                  </span>
+                )}
               </div>
               <div className="flex items-center gap-3">
-                <a
-                  href={previewUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-all text-sm"
-                >
-                  <ExternalLink className="w-4 h-4" />
-                  新しいタブで開く
-                </a>
+                {previewingRevision && (
+                  <button
+                    onClick={handlePreviewCurrent}
+                    className="flex items-center gap-2 px-4 py-2 bg-green-500/20 text-green-400 rounded-lg hover:bg-green-500/30 transition-all text-sm"
+                  >
+                    <Eye className="w-4 h-4" />
+                    最新版に戻る
+                  </button>
+                )}
+                {!previewingRevision && (
+                  <a
+                    href={previewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-all text-sm"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                    新しいタブで開く
+                  </a>
+                )}
                 <button
-                  onClick={() => setShowPreviewModal(false)}
+                  onClick={() => { setShowPreviewModal(false); setPreviewingRevision(null); }}
                   className="p-2 text-slate-400 hover:text-white hover:bg-white/10 rounded-lg transition-all"
                 >
                   <X className="w-5 h-5" />
@@ -1456,7 +1528,9 @@ export default function ContentPage() {
                     <Wand2 className="w-4 h-4 text-purple-400" />
                     <span className="text-sm font-semibold text-white">LP調整</span>
                   </div>
-                  <p className="text-xs text-slate-400 mt-1">修正したい内容を日本語で入力してください</p>
+                  <p className="text-xs text-slate-400 mt-1">
+                    {previewingRevision ? "最新版に戻ってから調整できます" : "修正したい内容を日本語で入力してください"}
+                  </p>
                 </div>
 
                 {/* 入力エリア */}
@@ -1467,14 +1541,14 @@ export default function ContentPage() {
                     placeholder="例：CTAボタンを紺色にしてください&#10;例：ヒーローセクションのキャッチコピーをもっと力強い表現に"
                     rows={4}
                     className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-slate-500 focus:outline-none focus:border-purple-500 text-sm resize-none"
-                    disabled={adjustingLp}
+                    disabled={adjustingLp || !!previewingRevision}
                   />
                   {lpAdjustError && (
                     <p className="text-red-400 text-xs mt-1">{lpAdjustError}</p>
                   )}
                   <button
                     onClick={handleAdjustLp}
-                    disabled={adjustingLp || !lpAdjustInstruction.trim()}
+                    disabled={adjustingLp || !lpAdjustInstruction.trim() || !!previewingRevision}
                     className="mt-2 w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-gradient-to-r from-purple-500 to-cyan-500 text-white rounded-lg hover:from-purple-600 hover:to-cyan-600 transition-all font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {adjustingLp ? (
@@ -1510,12 +1584,28 @@ export default function ContentPage() {
                     return (
                       <div className="space-y-2">
                         {recent.map((entry) => (
-                          <div key={entry.revision_id} className="bg-white/5 rounded-lg p-2.5 border border-white/10">
+                          <div
+                            key={entry.revision_id}
+                            className={`bg-white/5 rounded-lg p-2.5 border transition-all ${previewingRevision?.revision_id === entry.revision_id ? "border-amber-500/50 bg-amber-500/10" : "border-white/10"}`}
+                          >
                             <p className="text-xs text-white font-medium truncate">{entry.summary}</p>
                             <p className="text-xs text-slate-400 mt-0.5 line-clamp-2">{entry.instruction}</p>
-                            <p className="text-xs text-slate-500 mt-1">
-                              {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
-                            </p>
+                            <div className="flex items-center justify-between mt-1.5">
+                              <p className="text-xs text-slate-500">
+                                {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                              </p>
+                              {previewingRevision?.revision_id === entry.revision_id ? (
+                                <span className="text-xs text-amber-400 font-medium">表示中</span>
+                              ) : (
+                                <button
+                                  onClick={() => handlePreviewRevision(entry)}
+                                  className="flex items-center gap-1 px-2 py-0.5 bg-blue-500/20 text-blue-400 rounded hover:bg-blue-500/30 transition-all text-xs"
+                                >
+                                  <Eye className="w-3 h-3" />
+                                  表示
+                                </button>
+                              )}
+                            </div>
                           </div>
                         ))}
                       </div>

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Instagram, Loader2, Wand2, FileCode, Image, MessageSquare, CheckCircle, AlertCircle, Eye, ExternalLink, X, Link2, Upload } from "lucide-react";
+import { Instagram, Loader2, Wand2, FileCode, Image, MessageSquare, CheckCircle, AlertCircle, Eye, ExternalLink, X, Link2, Upload, Send, History } from "lucide-react";
 import { useHotel } from "@/lib/hotel-context";
 import { marketingApi, facilityApi, MarketingPlan, CreativeAsset, HotelResponse, SNSPostResponse } from "@/lib/api";
 import Link from "next/link";
@@ -60,6 +60,11 @@ export default function ContentPage() {
     setToast(message);
     toastTimerRef.current = setTimeout(() => setToast(null), 2000);
   };
+
+  // LP調整関連のstate（Issue #2）
+  const [lpAdjustInstruction, setLpAdjustInstruction] = useState<string>("");
+  const [adjustingLp, setAdjustingLp] = useState(false);
+  const [lpAdjustError, setLpAdjustError] = useState<string>("");
 
   // SNS投稿ジェネレーター関連のstate
   const [snsPlatform, setSnsPlatform] = useState<string>("");
@@ -248,9 +253,9 @@ export default function ContentPage() {
     const asset = assets[0];
     if (!asset || !asset.lp_source_code) return;
     
-    // 既にプレビューURLがある場合はそれを使用
+    // 既にプレビューURLがある場合はそれを使用（キャッシュバスターを付与）
     if (asset.lp_preview_url) {
-      setPreviewUrl(`${API_BASE_URL}${asset.lp_preview_url}`);
+      setPreviewUrl(`${API_BASE_URL}${asset.lp_preview_url}?t=${Date.now()}`);
       setShowPreviewModal(true);
       return;
     }
@@ -296,6 +301,29 @@ export default function ContentPage() {
       alert("LPの保存に失敗しました");
     } finally {
       setSavingLp(false);
+    }
+  };
+
+  // LP調整ハンドラー（Issue #2）
+  const handleAdjustLp = async () => {
+    const asset = assets[0];
+    if (!asset || !lpAdjustInstruction.trim()) return;
+    setAdjustingLp(true);
+    setLpAdjustError("");
+    try {
+      const updatedAsset = await marketingApi.adjustLp(hotelId, asset.id, lpAdjustInstruction.trim());
+      setAssets([updatedAsset]);
+      // キャッシュバスターを付与してiframeを強制リロード
+      if (updatedAsset.lp_preview_url) {
+        setPreviewUrl(`${API_BASE_URL}${updatedAsset.lp_preview_url}?t=${Date.now()}`);
+      }
+      setLpAdjustInstruction("");
+      showToast("LPを調整しました");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "LP調整に失敗しました";
+      setLpAdjustError(msg);
+    } finally {
+      setAdjustingLp(false);
     }
   };
 
@@ -1384,9 +1412,9 @@ export default function ContentPage() {
       {/* LPプレビューモーダル - Portalで画面全体に表示 */}
       {showPreviewModal && previewUrl && typeof document !== "undefined" && createPortal(
         <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm">
-          <div className="relative w-full max-w-6xl h-[90vh] bg-slate-900 rounded-2xl overflow-hidden shadow-2xl border border-white/10">
+          <div className="relative w-full max-w-7xl h-[92vh] bg-slate-900 rounded-2xl overflow-hidden shadow-2xl border border-white/10 flex flex-col">
             {/* ヘッダー */}
-            <div className="flex items-center justify-between px-6 py-4 bg-slate-800/50 border-b border-white/10">
+            <div className="flex items-center justify-between px-6 py-4 bg-slate-800/50 border-b border-white/10 flex-shrink-0">
               <div className="flex items-center gap-3">
                 <Eye className="w-5 h-5 text-blue-400" />
                 <h3 className="text-lg font-semibold text-white">LPプレビュー</h3>
@@ -1409,14 +1437,92 @@ export default function ContentPage() {
                 </button>
               </div>
             </div>
-            
-            {/* iframe プレビュー */}
-            <div className="w-full h-[calc(100%-72px)] bg-white">
-              <iframe
-                src={previewUrl}
-                className="w-full h-full border-0"
-                title="LP Preview"
-              />
+
+            {/* メインコンテンツ: プレビュー + 調整パネル */}
+            <div className="flex flex-1 overflow-hidden">
+              {/* iframe プレビュー */}
+              <div className="flex-1 bg-white">
+                <iframe
+                  src={previewUrl}
+                  className="w-full h-full border-0"
+                  title="LP Preview"
+                />
+              </div>
+
+              {/* LP調整パネル（右サイドバー）*/}
+              <div className="w-80 flex flex-col bg-slate-800/60 border-l border-white/10 overflow-hidden">
+                <div className="px-4 py-3 border-b border-white/10 flex-shrink-0">
+                  <div className="flex items-center gap-2">
+                    <Wand2 className="w-4 h-4 text-purple-400" />
+                    <span className="text-sm font-semibold text-white">LP調整</span>
+                  </div>
+                  <p className="text-xs text-slate-400 mt-1">修正したい内容を日本語で入力してください</p>
+                </div>
+
+                {/* 入力エリア */}
+                <div className="px-4 py-3 flex-shrink-0">
+                  <textarea
+                    value={lpAdjustInstruction}
+                    onChange={(e) => setLpAdjustInstruction(e.target.value)}
+                    placeholder="例：CTAボタンを紺色にしてください&#10;例：ヒーローセクションのキャッチコピーをもっと力強い表現に"
+                    rows={4}
+                    className="w-full bg-white/5 border border-white/10 rounded-lg p-3 text-white placeholder-slate-500 focus:outline-none focus:border-purple-500 text-sm resize-none"
+                    disabled={adjustingLp}
+                  />
+                  {lpAdjustError && (
+                    <p className="text-red-400 text-xs mt-1">{lpAdjustError}</p>
+                  )}
+                  <button
+                    onClick={handleAdjustLp}
+                    disabled={adjustingLp || !lpAdjustInstruction.trim()}
+                    className="mt-2 w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-gradient-to-r from-purple-500 to-cyan-500 text-white rounded-lg hover:from-purple-600 hover:to-cyan-600 transition-all font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {adjustingLp ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        調整中...
+                      </>
+                    ) : (
+                      <>
+                        <Send className="w-4 h-4" />
+                        調整を適用する
+                      </>
+                    )}
+                  </button>
+                </div>
+
+                {/* 修正履歴 */}
+                <div className="flex-1 overflow-y-auto px-4 py-3 border-t border-white/10">
+                  <div className="flex items-center gap-2 mb-3">
+                    <History className="w-4 h-4 text-slate-400" />
+                    <span className="text-xs font-semibold text-slate-300">修正履歴</span>
+                  </div>
+                  {(() => {
+                    const history = assets[0]?.lp_revision_history ?? [];
+                    const recent = [...history].reverse().slice(0, 5);
+                    if (recent.length === 0) {
+                      return (
+                        <p className="text-xs text-slate-500 text-center py-4">
+                          まだ修正履歴はありません
+                        </p>
+                      );
+                    }
+                    return (
+                      <div className="space-y-2">
+                        {recent.map((entry) => (
+                          <div key={entry.revision_id} className="bg-white/5 rounded-lg p-2.5 border border-white/10">
+                            <p className="text-xs text-white font-medium truncate">{entry.summary}</p>
+                            <p className="text-xs text-slate-400 mt-0.5 line-clamp-2">{entry.instruction}</p>
+                            <p className="text-xs text-slate-500 mt-1">
+                              {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })()}
+                </div>
+              </div>
             </div>
           </div>
         </div>,

--- a/frontend/src/app/marketing/[hotelId]/content/page.tsx
+++ b/frontend/src/app/marketing/[hotelId]/content/page.tsx
@@ -1615,7 +1615,9 @@ export default function ContentPage() {
                             className={`bg-white/5 rounded-lg p-2.5 border transition-all ${previewingRevision?.revision_id === entry.revision_id ? "border-amber-500/50 bg-amber-500/10" : "border-white/10"}`}
                           >
                             <p className="text-xs text-white font-medium truncate">{entry.summary}</p>
-                            <p className="text-xs text-slate-400 mt-0.5 line-clamp-2">{entry.instruction}</p>
+                            {entry.instruction !== "初版生成" && (
+                              <p className="text-xs text-slate-400 mt-0.5 line-clamp-2">{entry.instruction}</p>
+                            )}
                             <div className="flex items-center justify-between mt-1.5">
                               <p className="text-xs text-slate-500">
                                 {new Date(entry.timestamp).toLocaleString("ja-JP", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -892,6 +892,14 @@ export interface MarketingPlan {
   updated_at: string;
 }
 
+export interface LpRevisionEntry {
+  revision_id: string;
+  instruction: string;
+  summary: string;
+  timestamp: string;
+  lp_source_code: string;
+}
+
 export interface CreativeAsset {
   id: number;
   marketing_plan_id: number;
@@ -902,6 +910,7 @@ export interface CreativeAsset {
   ad_copy: AdCopyContent;
   ota_text: OTATextContent;
   generation_prompts: Record<string, unknown>;
+  lp_revision_history: LpRevisionEntry[];
   created_at: string;
   updated_at: string;
 }
@@ -1686,6 +1695,24 @@ export const marketingApi = {
     }
 
     return response.json();
+  },
+
+  /**
+   * LP調整: 自然言語の修正指示をLLMに渡してHTMLを差分更新する（Issue #2）
+   */
+  async adjustLp(
+    hotelId: number,
+    assetId: number,
+    instruction: string
+  ): Promise<CreativeAsset> {
+    return apiRequest<CreativeAsset>(
+      `/api/creative/hotels/${hotelId}/assets/${assetId}/adjust-lp`,
+      {
+        method: "POST",
+        body: JSON.stringify({ instruction }),
+      },
+      "facility"
+    );
   },
 
   // ============================================


### PR DESCRIPTION
## Summary

- LP調整エンドポイント（`POST /assets/{asset_id}/adjust-lp`）の追加とバックエンド実装
- プレビューモーダルにLP調整パネル（修正指示入力・修正履歴表示）を追加
- 発信する画面の修正履歴からBlobURLを使って過去バージョンのHTMLをプレビュー表示
- 修正履歴をLP画像の右側に横並びで配置（レイアウト最適化）

## 変更内容

**バックエンド**
- `lp_revision_history` カラムを `creative_assets` テーブルに追加
- `LpAdjustRequest` / `LpRevisionEntry` Pydanticスキーマを追加
- `adjust_landing_page()` サービス関数（2段階LLM差分更新）を実装
- `POST /hotels/{hotel_id}/assets/{asset_id}/adjust-lp` エンドポイントを追加

**フロントエンド**
- プレビューモーダルにLP調整パネル（修正指示 + 修正履歴）を追加
- 修正履歴の各エントリに「表示」ボタン → 過去バージョンをBlobURLでiframe表示
- 過去バージョン表示中は「過去バージョン表示中」バッジ＋「最新版に戻る」ボタンを表示
- 発信する画面でLP画像の右側に修正履歴を横並び配置

## スクショ

<img height="500" alt="image" src="https://github.com/user-attachments/assets/25f72923-5c10-4d63-9163-803497da0b57" />

<img height="500" alt="image" src="https://github.com/user-attachments/assets/a06baa13-72c6-4e2d-8e01-faa8980f7531" />
<img height="500" height="738" alt="image" src="https://github.com/user-attachments/assets/db17cb6b-8b99-4f2d-85a8-a41165848ce2" />
<img height="500"alt="image" src="https://github.com/user-attachments/assets/70c5dec2-2420-4ddd-9d53-db2d99a7f6d4" />
<img height="500" alt="image" src="https://github.com/user-attachments/assets/4cfac464-a6ae-4a4a-8fbb-5bd5da384bec" />


## Test plan

- [x] LP生成後、プレビューモーダルを開いてLP調整フォームに修正指示を入力・送信できる
- [x] 送信後、プレビューが更新され修正履歴に追加される
- [x] 修正履歴の「表示」ボタンで過去バージョンがiframeに反映される
- [x] 「最新版に戻る」で現在のLPに戻れる
- [x] 発信する画面でLP画像と修正履歴が横並びで表示される
